### PR TITLE
reverse the result order of tenancy.GetTenancyPath

### DIFF
--- a/pkg/tenancy/accessor.go
+++ b/pkg/tenancy/accessor.go
@@ -179,5 +179,13 @@ func (a *TenancyAccessor) GetTenancyPath(ctx context.Context, tenantId string) (
 		}
 		path = append(path, id)
 	}
+
+	//reverse the order to that the result is curent tenant id -> root tenant id
+	//fi is index going forward starting from 0,
+	//ri is index going backward starting from last element
+	//swap the element at ri and ri
+	for fi, ri := 0, len(path)-1; fi < ri; fi, ri = fi+1, ri-1 {
+		path[fi], path[ri] = path[ri], path[fi]
+	}
 	return path, nil
 }


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-04-08T12:18:36Z" title="Thursday, April 8th 2021, 8:18:36 am -04:00">Apr 8, 2021</time>_
_Merged <time datetime="2021-04-08T12:18:43Z" title="Thursday, April 8th 2021, 8:18:43 am -04:00">Apr 8, 2021</time>_
---

reverse the result order of tenancy.GetTenancyPath to make it consistent with db migration implementation. if hierarchy is A -> B -> C where -> indicates parent -> children. The result of this call for tenant C will return  [A, B, C]