### PR TITLE
make swagger api-doc use x-forwarded-host for the host field.

### DIFF
--- a/pkg/swagger/controllers.go
+++ b/pkg/swagger/controllers.go
@@ -169,7 +169,7 @@ func (s *SwaggerController) swaggerSpec(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var host string
-	fwdAddress := r.Header.Get("X-Forwarded-For") // capitalisation doesn't matter
+	fwdAddress := r.Header.Get("X-Forwarded-Host") // capitalisation doesn't matter
 	if fwdAddress != "" {
 		ips := strings.Split(fwdAddress, ",")
 		 host = strings.TrimSpace(ips[0])


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-07-13T21:18:32Z" title="Tuesday, July 13th 2021, 5:18:32 pm -04:00">Jul 13, 2021</time>_
_Merged <time datetime="2021-07-16T19:26:04Z" title="Friday, July 16th 2021, 3:26:04 pm -04:00">Jul 16, 2021</time>_
---

when the request passes through router service, x-forwarded-host has both the original host and the original port.