### PR TITLE
Fix/encrypted raw nil

### DIFF
--- a/pkg/data/types/pqcrypt/context.go
+++ b/pkg/data/types/pqcrypt/context.go
@@ -113,6 +113,9 @@ func (EncryptedRaw) GormDataType() string {
 
 // Value implements driver.Valuer
 func (d *EncryptedRaw) Value() (driver.Value, error) {
+	//we need to check nil here instead of in the JsonbValue method
+	//because the input to JsonbValue is interface{}. Since d has a type
+	// the v==nil check in JsonbValue won't return true
 	if d == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-07-30T21:30:11Z" title="Friday, July 30th 2021, 5:30:11 pm -04:00">Jul 30, 2021</time>_
_Merged <time datetime="2021-07-30T21:41:12Z" title="Friday, July 30th 2021, 5:41:12 pm -04:00">Jul 30, 2021</time>_
---

Because the nil check fails, the actual data saved in db is the result of json.unmarshall(nil) which is a 'null' string instead of the null db type.