### PR TITLE
US35705  ignore unsupported jwt keys

### DIFF
--- a/pkg/security/oauth2/jwt/jwk_store_file.go
+++ b/pkg/security/oauth2/jwt/jwk_store_file.go
@@ -34,15 +34,16 @@ func NewFileJwkStore(props CryptoProperties) *FileJwkStore {
 	// load files
 	for k, v := range props.Keys {
 		jwks, e := loadJwks(k, v)
-		if e != nil {
-			panic(e)
-		}
-		for _, jwk := range jwks {
-			s.cacheById[jwk.Id()] = jwk
+		// ignore unsupported keys
+		if e == nil {
+			for _, jwk := range jwks {
+				s.cacheById[jwk.Id()] = jwk
 
+			}
+			s.cacheByName[k] = jwks
+			s.indexes[k] = 0
 		}
-		s.cacheByName[k] = jwks
-		s.indexes[k] = 0
+		
 	}
 
 	return &s


### PR DESCRIPTION
> [<img alt="xinzlu" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/xinzlu) **Authored by [xinzlu](https://cto-github.cisco.com/xinzlu)**
_<time datetime="2021-08-17T18:54:40Z" title="Tuesday, August 17th 2021, 2:54:40 pm -04:00">Aug 17, 2021</time>_
_Merged <time datetime="2021-08-17T19:14:49Z" title="Tuesday, August 17th 2021, 3:14:49 pm -04:00">Aug 17, 2021</time>_
---

there are jks keys used by other services.
```
  security.jwt.key-name: "jwt-jks"
  security.keys.jwt-jks.type: "{{ jwt.jks.type }}"
  security.keys.jwt-jks.format: "{{ jwt.jks.format }}"
  security.keys.jwt-jks.file: "{{ jwt.jks.file }}"
  security.keys.jwt-jks.alias: "{{ jwt.jks.alias }}"
  security.keys.jwt-pem.type: "{{ jwt.pem.type }}"
  security.keys.jwt-pem.format: "{{ jwt.pem.format }}"
  security.keys.jwt-pem.file: "{{ jwt.pem.file }}"
```