### PR TITLE
Make consul discovery tag comma separated slice

### DIFF
--- a/pkg/discovery/properties.go
+++ b/pkg/discovery/properties.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/bootstrap"
+	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/utils"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/web"
 	"fmt"
 	"github.com/pkg/errors"
@@ -15,7 +16,7 @@ const (
 type DiscoveryProperties struct {
 	HealthCheckPath            string   `json:"health-check-path"`
 	HealthCheckInterval        string   `json:"health-check-interval"`
-	Tags                       []string `json:"tags"`
+	Tags                       utils.CommaSeparatedSlice `json:"tags"`
 	AclToken                   string   `json:"acl-token"`
 	IpAddress                  string   `json:"ip-address"` //A pre-defined IP address
 	Interface                  string   `json:"interface"`    //The network interface from where to get the ip address. If IpAddress is defined, this field is ignored


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-08-17T21:16:29Z" title="Tuesday, August 17th 2021, 5:16:29 pm -04:00">Aug 17, 2021</time>_
_Closed <time datetime="2021-08-17T21:17:13Z" title="Tuesday, August 17th 2021, 5:17:13 pm -04:00">Aug 17, 2021</time>_
---

because environment, consul and vault add "" around property values, we need comma separated list to denote string slices.