### PR TITLE
security should use tenant externalId instead of tenant name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
-	github.com/prometheus/common v0.7.0
 	github.com/rs/cors v1.7.0
 	github.com/russellhaering/goxmldsig v1.1.0
 	github.com/spf13/cobra v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,8 @@ github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
@@ -401,7 +399,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -545,7 +542,6 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7q
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -584,7 +580,6 @@ github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhr
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -877,7 +872,6 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/data/types/gorm_model_test.go
+++ b/pkg/data/types/gorm_model_test.go
@@ -51,7 +51,7 @@ func SubTestExampleUseScope(di *tenancyAccessorDI) test.GomegaSubTestFunc {
 			d.UserId = "any-user-id"
 			d.TenantId = tenantId.String()
 			d.Tenants = utils.NewStringSet(tenantId.String())
-			d.TenantName = "any-tenant-name"
+			d.TenantExternalId = "any-tenant-ext-id"
 			d.Permissions = utils.NewStringSet(security.SpecialPermissionSwitchTenant)
 		})
 

--- a/pkg/integrate/security/scope/base.go
+++ b/pkg/integrate/security/scope/base.go
@@ -100,7 +100,7 @@ func (b *managerBase) prepareCacheKey(scope *Scope, srcUsername string) {
 		src:        srcUsername,
 		username:   scope.username,
 		userId:     scope.userId,
-		tenantName: scope.tenantName,
+		tenantExternalId: scope.tenantExternalId,
 		tenantId:   scope.tenantId,
 	}
 }
@@ -113,14 +113,14 @@ func (b *managerBase) isSameUser(username, userId string, auth security.Authenti
 	return username != "" && username == un || userId != "" && userId == id
 }
 
-func (b *managerBase) isSameTenant(tenantName, tenantId string, auth security.Authentication) bool {
-	if tenantName == "" && tenantId == "" {
+func (b *managerBase) isSameTenant(tenantExternalId, tenantId string, auth security.Authentication) bool {
+	if tenantExternalId == "" && tenantId == "" {
 		return true
 	}
 
 	switch details := auth.Details().(type) {
 	case security.TenantDetails:
-		return tenantId != "" && tenantId == details.TenantId() || tenantName != "" && tenantName == details.TenantName()
+		return tenantId != "" && tenantId == details.TenantId() || tenantExternalId != "" && tenantExternalId == details.TenantExternalId()
 	default:
 		return false
 	}

--- a/pkg/integrate/security/scope/cache.go
+++ b/pkg/integrate/security/scope/cache.go
@@ -13,7 +13,7 @@ type cKey struct {
 	src        string // source username
 	username   string // target username
 	userId     string // target userId
-	tenantName string // target tenantName
+	tenantExternalId string // target tenantExternalId
 	tenantId   string // target tenantId
 }
 
@@ -24,7 +24,7 @@ func (k cKey) String() string {
 	}
 	tenant := k.tenantId
 	if tenant == "" {
-		tenant = k.tenantName
+		tenant = k.tenantExternalId
 	}
 	return fmt.Sprintf("%s->%s@%s", k.src, user, tenant)
 }

--- a/pkg/integrate/security/scope/context.go
+++ b/pkg/integrate/security/scope/context.go
@@ -29,7 +29,7 @@ type Options func(*Scope)
 type Scope struct {
 	username   string // target username
 	userId     string // target userId
-	tenantName string // target tenantName
+	tenantExternalId string // target tenantExternalId
 	tenantId   string // target tenantId
 	time       time.Time
 	useSysAcct bool
@@ -51,7 +51,7 @@ func (s Scope) String() string {
 	if s.username != "" {
 		user = s.username
 	}
-	tenant := s.tenantName
+	tenant := s.tenantExternalId
 	if s.tenantId != "" {
 		tenant = s.tenantId
 	}
@@ -93,7 +93,7 @@ func (s *Scope) validate(_ context.Context) error {
 	if s.username != "" && s.userId != "" {
 		return ErrUserIdAndUsernameExclusive
 	}
-	if s.tenantName != "" && s.tenantId != "" {
+	if s.tenantExternalId != "" && s.tenantId != "" {
 		return ErrTenantIdAndNameExclusive
 	}
 	return nil

--- a/pkg/integrate/security/scope/manager.go
+++ b/pkg/integrate/security/scope/manager.go
@@ -200,8 +200,8 @@ func (m *defaultScopeManager) passwordLogin(ctx context.Context, pKey *cKey) (*s
 	authOpts := []seclient.AuthOptions{
 		seclient.WithCredentials(pKey.username, p),
 	}
-	if pKey.tenantName != "" || pKey.tenantId != "" {
-		authOpts = append(authOpts, seclient.WithTenant(pKey.tenantId, pKey.tenantName))
+	if pKey.tenantExternalId != "" || pKey.tenantId != "" {
+		authOpts = append(authOpts, seclient.WithTenant(pKey.tenantId, pKey.tenantExternalId))
 	}
 	return m.client.PasswordLogin(ctx, authOpts...)
 }
@@ -216,13 +216,13 @@ func (m *defaultScopeManager) switchContext(ctx context.Context, pKey *cKey, aut
 	authOpts := []seclient.AuthOptions{
 		seclient.WithAuthentication(auth),
 	}
-	if pKey.tenantName != "" || pKey.tenantId != ""{
-		authOpts = append(authOpts, seclient.WithTenant(pKey.tenantId, pKey.tenantName))
+	if pKey.tenantExternalId != "" || pKey.tenantId != ""{
+		authOpts = append(authOpts, seclient.WithTenant(pKey.tenantId, pKey.tenantExternalId))
 	}
 
 	if m.isSameUser(pKey.username, pKey.userId, auth) {
 		// switch tenant
-		if m.isSameTenant(pKey.tenantName, pKey.tenantId, auth) {
+		if m.isSameTenant(pKey.tenantExternalId, pKey.tenantId, auth) {
 			return nil, nil
 		} else {
 			return m.client.SwitchTenant(ctx, authOpts...)

--- a/pkg/integrate/security/scope/manager_test/manager_test.go
+++ b/pkg/integrate/security/scope/manager_test/manager_test.go
@@ -22,20 +22,20 @@ import (
 )
 
 const (
-	defaultTenantId   = "id-tenant-1"
-	defaultTenantName = "tenant-1"
-	systemUsername    = "system"
-	systemUserId      = "id-system"
+	defaultTenantId         = "id-tenant-1"
+	defaultTenantExternalId = "tenant-1"
+	systemUsername          = "system"
+	systemUserId            = "id-system"
 
 	adminUsername = "admin"
 	adminUserId   = "id-admin"
 	username      = "regular"
 	userId        = "id-regular"
 
-	tenantId      = "id-tenant-2"
-	tenantName    = "tenant-2"
-	badTenantId   = "id-tenant-3"
-	badTenantName = "tenant-3"
+	tenantId            = "id-tenant-2"
+	tenantExternalId    = "tenant-2"
+	badTenantId         = "id-tenant-3"
+	badTenantExternalId = "tenant-3"
 
 	validity = 10 * time.Second
 )
@@ -133,7 +133,7 @@ func SubTestSysAcctLogin() test.GomegaSubTestFunc {
 			doAssertCurrentScope(ctx, g, "SysAcctLogin",
 				assertAuthenticated(),
 				assertWithUser(systemUsername, systemUserId),
-				assertWithTenant(defaultTenantId, defaultTenantName),
+				assertWithTenant(defaultTenantId, defaultTenantExternalId),
 				assertNotProxyAuth(),
 				assertValidityGreaterThan(validity),
 			)
@@ -150,7 +150,7 @@ func SubTestSysAcctWithTenant() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "SysAcct+TenantId",
 					assertAuthenticated(),
 					assertWithUser(systemUsername, systemUserId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
@@ -158,17 +158,17 @@ func SubTestSysAcctWithTenant() test.GomegaSubTestFunc {
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 		{
-			// use tenantName and existing auth
+			// use tenantExternalId and existing auth
 			ctx = sectest.WithMockedSecurity(ctx, securityMockRegular())
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "SysAcct+TenantName",
+				doAssertCurrentScope(ctx, g, "SysAcct+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(systemUsername, systemUserId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.UseSystemAccount(), scope.WithTenantName(tenantName))
+			}, scope.UseSystemAccount(), scope.WithTenantExternalId(tenantExternalId))
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 	}
@@ -184,7 +184,7 @@ func SubTestSwitchUserUsingSysAcct() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -198,7 +198,7 @@ func SubTestSwitchUserUsingSysAcct() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SysAcct+UserId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -216,7 +216,7 @@ func SubTestSwitchUserWithTenantUsingSysAcct() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username+TenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -227,14 +227,14 @@ func SubTestSwitchUserWithTenantUsingSysAcct() test.GomegaSubTestFunc {
 			// use tenent Name and existing auth
 			ctx = sectest.WithMockedSecurity(ctx, securityMockRegular())
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.WithUserId(userId), scope.WithTenantName(tenantName), scope.UseSystemAccount())
+			}, scope.WithUserId(userId), scope.WithTenantExternalId(tenantExternalId), scope.UseSystemAccount())
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 	}
@@ -251,7 +251,7 @@ func SubTestSwitchUser() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+Username",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -264,7 +264,7 @@ func SubTestSwitchUser() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+UserId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -283,7 +283,7 @@ func SubTestSwitchUserWithTenant() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+Username+TenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -291,16 +291,16 @@ func SubTestSwitchUserWithTenant() test.GomegaSubTestFunc {
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 		{
-			// use tenantName
+			// use tenantExternalId
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+Username+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+Username+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.WithUsername(username), scope.WithTenantName(tenantName))
+			}, scope.WithUsername(username), scope.WithTenantExternalId(tenantExternalId))
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 
@@ -318,7 +318,7 @@ func SubTestSwitchTenant() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+TenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
@@ -326,16 +326,16 @@ func SubTestSwitchTenant() test.GomegaSubTestFunc {
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 		{
-			// use tenantName
+			// use tenantExternalId
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.WithTenantName(tenantName))
+			}, scope.WithTenantExternalId(tenantExternalId))
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 
@@ -390,10 +390,10 @@ func SubTestValidityNotGuaranteed(di *ManagerTestDI) test.GomegaSubTestFunc {
 		{
 			// invocation
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityLessThan(validity),
 				)
@@ -406,10 +406,10 @@ func SubTestValidityNotGuaranteed(di *ManagerTestDI) test.GomegaSubTestFunc {
 		{
 			// immediate replay
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Replay Switch+TenantName",
+				doAssertCurrentScope(ctx, g, "Replay Switch+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityLessThan(validity),
 				)
@@ -460,7 +460,7 @@ func SubTestInsufficientAccess() test.GomegaSubTestFunc {
 			// cannot switch tenant
 			e := scope.Do(ctx, func(ctx context.Context) {
 				t.Errorf("scoped function should be be invoked in case of error")
-			}, scope.WithTenantId(badTenantName))
+			}, scope.WithTenantId(badTenantExternalId))
 
 			g.Expect(e).To(Not(Succeed()), "scope manager should returns error")
 		}
@@ -485,7 +485,7 @@ func SubTestSwitchToSameUser(di *ManagerTestDI) test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SameUsername",
 					assertAuthenticated(),
 					assertWithUser(adminUsername, adminUserId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertNotProxyAuth(),
 				)
 			}, scope.WithUsername(adminUsername))
@@ -509,7 +509,7 @@ func SubTestSwitchToSameTenant(di *ManagerTestDI) test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SameTenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertNotProxyAuth(),
 				)
 			}, scope.WithTenantId(defaultTenantId))
@@ -533,7 +533,7 @@ func SubTestRevokedToken(di *ManagerTestDI) test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+TenantId",
 					assertAuthenticated(),
 					assertWithUser(adminUsername, adminUserId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 				)
 				toBeRevoked = security.Get(ctx).(oauth2.Authentication).AccessToken().Value()
@@ -551,7 +551,7 @@ func SubTestRevokedToken(di *ManagerTestDI) test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+TenantId",
 					assertAuthenticated(),
 					assertWithUser(adminUsername, adminUserId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 				)
 			}, scope.WithTenantId(tenantId))
@@ -605,7 +605,7 @@ func assertWithUser(username, uid string) assertion {
 	}
 }
 
-func assertWithTenant(id, name string) assertion {
+func assertWithTenant(id, externalId string) assertion {
 	return func(g *WithT, auth security.Authentication, msg string) {
 		details, ok := auth.Details().(security.TenantDetails)
 		g.Expect(ok).To(BeTrue(), "[%s] auth details should be TenantDetails", msg)
@@ -614,8 +614,8 @@ func assertWithTenant(id, name string) assertion {
 			g.Expect(details.TenantId()).To(Equal(id), "[%s] should authenticated as tenant ID [%s]", msg, id)
 		}
 
-		if name != "" {
-			g.Expect(details.TenantName()).To(Equal(name), "[%s] should authenticated as tenant name [%s]", msg, name)
+		if externalId != "" {
+			g.Expect(details.TenantExternalId()).To(Equal(externalId), "[%s] should authenticated as tenant externalId [%s]", msg, externalId)
 		}
 	}
 }
@@ -665,7 +665,7 @@ func assertValidityGreaterThan(validity time.Duration) assertion {
 //		d.Username = systemUsername
 //		d.UserId = systemUserId
 //		d.TenantId = defaultTenantId
-//		d.TenantName = defaultTenantName
+//		d.TenantExternalId = defaultTenantExternalId
 //		d.Permissions = utils.NewStringSet(
 //			security.SpecialPermissionAccessAllTenant,
 //			security.SpecialPermissionSwitchUser,
@@ -678,7 +678,7 @@ func securityMockAdmin() sectest.SecurityMockOptions {
 		d.Username = adminUsername
 		d.UserId = adminUserId
 		d.TenantId = defaultTenantId
-		d.TenantName = defaultTenantName
+		d.TenantExternalId = defaultTenantExternalId
 		d.Permissions = utils.NewStringSet(
 			security.SpecialPermissionSwitchUser,
 			security.SpecialPermissionSwitchTenant)
@@ -690,7 +690,7 @@ func securityMockRegular() sectest.SecurityMockOptions {
 		d.Username = username
 		d.UserId = userId
 		d.TenantId = defaultTenantId
-		d.TenantName = defaultTenantName
+		d.TenantExternalId = defaultTenantExternalId
 		d.Permissions = utils.NewStringSet(security.SpecialPermissionSwitchTenant)
 	}
 }

--- a/pkg/integrate/security/scope/options.go
+++ b/pkg/integrate/security/scope/options.go
@@ -16,14 +16,14 @@ func WithUserId(userId string) Options {
 
 func WithTenantId(tenantId string) Options {
 	return func(s *Scope) {
-		s.tenantName = ""
+		s.tenantExternalId = ""
 		s.tenantId = tenantId
 	}
 }
 
-func WithTenantName(tenantName string) Options {
+func WithTenantExternalId(tenantExternalId string) Options {
 	return func(s *Scope) {
-		s.tenantName = tenantName
+		s.tenantExternalId = tenantExternalId
 		s.tenantId = ""
 	}
 }

--- a/pkg/integrate/security/seclient/client.go
+++ b/pkg/integrate/security/seclient/client.go
@@ -157,8 +157,8 @@ func (c *remoteAuthClient) reqOptionsForTenancy(opt *AuthOption) []httpclient.Re
 	if opt.TenantId != "" {
 		ret = append(ret, httpclient.WithParam(oauth2.ParameterTenantId, opt.TenantId))
 	}
-	if opt.TenantName != "" {
-		ret = append(ret, httpclient.WithParam(oauth2.ParameterTenantName, opt.TenantName))
+	if opt.TenantExternalId != "" {
+		ret = append(ret, httpclient.WithParam(oauth2.ParameterTenantExternalId, opt.TenantExternalId))
 	}
 	return ret
 }

--- a/pkg/integrate/security/seclient/context.go
+++ b/pkg/integrate/security/seclient/context.go
@@ -14,7 +14,7 @@ type AuthOption struct {
 	Username    string	// Username is used by password login and switch user
 	UserId      string	// UserId is used by switch user
 	TenantId    string	// TenantId is used by password login and switch user/tenant
-	TenantName  string	// TenantName is used by password login and switch user/tenant
+	TenantExternalId  string	// TenantExternalId is used by password login and switch user/tenant
 }
 
 type AuthenticationClient interface {
@@ -57,27 +57,27 @@ func WithAccessToken(accessToken string) AuthOptions {
 	}
 }
 
-// WithTenant create an options that specify tenant by either tenantId or tenantName
+// WithTenant create an options that specify tenant by either tenantId or tenantExternalId
 // username and userId are exclusive, cannot be both empty
-func WithTenant(tenantId string, tenantName string) AuthOptions {
+func WithTenant(tenantId string, tenantExternalId string) AuthOptions {
 	if tenantId != "" {
 		return WithTenantId(tenantId)
 	} else {
-		return WithTenantName(tenantName)
+		return WithTenantExternalId(tenantExternalId)
 	}
 }
 
 func WithTenantId(tenantId string) AuthOptions {
 	return func(opt *AuthOption) {
 		opt.TenantId = tenantId
-		opt.TenantName = ""
+		opt.TenantExternalId = ""
 	}
 }
 
-func WithTenantName(tenantName string) AuthOptions {
+func WithTenantExternalId(tenantExternalId string) AuthOptions {
 	return func(opt *AuthOption) {
 		opt.TenantId = ""
-		opt.TenantName = tenantName
+		opt.TenantExternalId = tenantExternalId
 	}
 }
 

--- a/pkg/security/account_hierarchy.go
+++ b/pkg/security/account_hierarchy.go
@@ -20,7 +20,7 @@ type Provider struct {
 
 type Tenant struct {
 	Id           string
-	Name         string
+	ExternalId   string
 	DisplayName  string
 	Description  string
 	ProviderId   string
@@ -39,5 +39,5 @@ type ProviderStore interface {
 
 type TenantStore interface {
 	LoadTenantById(ctx context.Context, id string) (*Tenant, error)
-	LoadTenantByName(ctx context.Context, name string) (*Tenant, error)
+	LoadTenantByExternalId(ctx context.Context, name string) (*Tenant, error)
 }

--- a/pkg/security/ctx_details.go
+++ b/pkg/security/ctx_details.go
@@ -26,7 +26,7 @@ type ProviderDetails interface {
 
 type TenantDetails interface {
 	TenantId() string
-	TenantName() string
+	TenantExternalId() string
 	TenantSuspended() bool
 }
 

--- a/pkg/security/example/inmemory_tenancy.go
+++ b/pkg/security/example/inmemory_tenancy.go
@@ -14,13 +14,13 @@ const (
 // security.TenantStore
 type MockedTenantStore struct {
 	ids map[string]*security.Tenant
-	names map[string]*security.Tenant
+	externalIds map[string]*security.Tenant
 }
 
 func NewTenantStore() security.TenantStore {
 	return &MockedTenantStore{
 		ids: map[string]*security.Tenant{},
-		names: map[string]*security.Tenant{},
+		externalIds: map[string]*security.Tenant{},
 	}
 }
 
@@ -30,28 +30,28 @@ func (s *MockedTenantStore) LoadTenantById(ctx context.Context, id string) (*sec
 		return tenant, nil
 	}
 	name := fmt.Sprintf("name-for-%s", id)
-	return s.new(id, name), nil
+	return s.new(id, name, name), nil
 }
 
-func (s *MockedTenantStore) LoadTenantByName(ctx context.Context, name string) (*security.Tenant, error) {
-	if tenant,ok := s.names[name]; ok {
+func (s *MockedTenantStore) LoadTenantByExternalId(ctx context.Context, externalId string) (*security.Tenant, error) {
+	if tenant,ok := s.externalIds[externalId]; ok {
 		return tenant, nil
 	}
-	id := fmt.Sprintf("id-for-%s", name)
-	return s.new(id, name), nil
+	id := fmt.Sprintf("id-for-%s", externalId)
+	return s.new(id, externalId, externalId), nil
 }
 
-func (s *MockedTenantStore) new(id, name string) *security.Tenant {
+func (s *MockedTenantStore) new(id, name string, externalId string) *security.Tenant {
 	tenant := security.Tenant{
 		Id:          id,
-		Name:        name,
+		ExternalId:  externalId,
 		DisplayName: name,
 		Description: fmt.Sprintf("This is a mocked tenant id=%s, name=%s", id, name),
 		ProviderId:  fmt.Sprintf("provider-%s", id),
 		Suspended:   false,
 	}
 	s.ids[id] = &tenant
-	s.names[name] = &tenant
+	s.externalIds[externalId] = &tenant
 	return &tenant
 }
 

--- a/pkg/security/oauth2/auth/claims/custom.go
+++ b/pkg/security/oauth2/auth/claims/custom.go
@@ -55,12 +55,12 @@ func TenantId(ctx context.Context, opt *FactoryOption) (v interface{}, err error
 	return nonZeroOrError(details.TenantId(), errorMissingDetails)
 }
 
-func TenantName(ctx context.Context, opt *FactoryOption) (v interface{}, err error) {
+func TenantExternalId(ctx context.Context, opt *FactoryOption) (v interface{}, err error) {
 	details, ok := opt.Source.Details().(security.TenantDetails)
 	if !ok {
 		return nil, errorMissingDetails
 	}
-	return nonZeroOrError(details.TenantName(), errorMissingDetails)
+	return nonZeroOrError(details.TenantExternalId(), errorMissingDetails)
 }
 
 func TenantSuspended(ctx context.Context, opt *FactoryOption) (v interface{}, err error) {

--- a/pkg/security/oauth2/auth/claims/specs_check_token.go
+++ b/pkg/security/oauth2/auth/claims/specs_check_token.go
@@ -32,7 +32,7 @@ var (
 		oauth2.ClaimAssignedTenants: Optional(AssignedTenants),
 		oauth2.ClaimDefaultTenantId: Optional(DefaultTenantId),
 		oauth2.ClaimTenantId:        Optional(TenantId),
-		oauth2.ClaimTenantName:      Optional(TenantName),
+		oauth2.ClaimTenantExternalId:      Optional(TenantExternalId),
 		oauth2.ClaimTenantSuspended: Optional(TenantSuspended),
 		oauth2.ClaimProviderId:      Optional(ProviderId),
 		oauth2.ClaimProviderName:    Optional(ProviderName),

--- a/pkg/security/oauth2/auth/claims/specs_id_token.go
+++ b/pkg/security/oauth2/auth/claims/specs_id_token.go
@@ -23,7 +23,7 @@ var (
 		oauth2.ClaimUserId:          Optional(UserId),
 		oauth2.ClaimAccountType:     Optional(AccountType),
 		oauth2.ClaimTenantId:        Optional(TenantId),
-		oauth2.ClaimTenantName:      Optional(TenantName),
+		oauth2.ClaimTenantExternalId:      Optional(TenantExternalId),
 		oauth2.ClaimTenantSuspended: Optional(TenantSuspended),
 		oauth2.ClaimProviderId:      Optional(ProviderId),
 		oauth2.ClaimProviderName:    Optional(ProviderName),

--- a/pkg/security/oauth2/auth/grants/switch_tenant.go
+++ b/pkg/security/oauth2/auth/grants/switch_tenant.go
@@ -94,13 +94,13 @@ func (g *SwitchTenantGranter) Grant(ctx context.Context, request *auth.TokenRequ
 
 func (g *SwitchTenantGranter) validateRequest(ctx context.Context, request *auth.TokenRequest) error {
 	tenantId, idOk := request.Extensions[oauth2.ParameterTenantId].(string)
-	tenantName, nameOk := request.Extensions[oauth2.ParameterTenantName].(string)
+	tenantExternalid, nameOk := request.Extensions[oauth2.ParameterTenantExternalId].(string)
 	if !nameOk && !idOk {
-		return oauth2.NewInvalidTokenRequestError(fmt.Sprintf("both [%s] and [%s] are missing", oauth2.ParameterTenantId, oauth2.ParameterTenantName))
+		return oauth2.NewInvalidTokenRequestError(fmt.Sprintf("both [%s] and [%s] are missing", oauth2.ParameterTenantId, oauth2.ParameterTenantExternalId))
 	}
 
-	if strings.TrimSpace(tenantId) == "" && strings.TrimSpace(tenantName) == "" {
-		return oauth2.NewInvalidTokenRequestError(fmt.Sprintf("both [%s] and [%s] are empty", oauth2.ParameterTenantId, oauth2.ParameterTenantName))
+	if strings.TrimSpace(tenantId) == "" && strings.TrimSpace(tenantExternalid) == "" {
+		return oauth2.NewInvalidTokenRequestError(fmt.Sprintf("both [%s] and [%s] are empty", oauth2.ParameterTenantId, oauth2.ParameterTenantExternalId))
 	}
 	return nil
 }
@@ -125,8 +125,8 @@ func (g *SwitchTenantGranter) validate(ctx context.Context, request *auth.TokenR
 		return oauth2.NewInvalidGrantError("cannot switch to same tenant")
 	}
 
-	tenantName, _ := request.Extensions[oauth2.ParameterTenantName].(string)
-	if strings.TrimSpace(tenantName) == srcTenant.TenantName() {
+	tenantExternalId, _ := request.Extensions[oauth2.ParameterTenantExternalId].(string)
+	if strings.TrimSpace(tenantExternalId) == srcTenant.TenantExternalId() {
 		return oauth2.NewInvalidGrantError("cannot switch to same tenant")
 	}
 	return nil

--- a/pkg/security/oauth2/auth/misc/check_token.go
+++ b/pkg/security/oauth2/auth/misc/check_token.go
@@ -149,7 +149,7 @@ func (ep *CheckTokenEndpoint) activeTokenResponseWithDetails(ctx context.Context
 //		Currency:        auth.Details().(security.UserDetails).CurrencyCode(),
 //		AssignedTenants: auth.Details().(security.UserDetails).AssignedTenantIds(),
 //		TenantId:        auth.Details().(security.TenantDetails).TenantId(),
-//		TenantName:      auth.Details().(security.TenantDetails).TenantName(),
+//		TenantExternalId:      auth.Details().(security.TenantDetails).TenantExternalId(),
 //		TenantSuspended: utils.BoolPtr(auth.Details().(security.TenantDetails).TenantSuspended()),
 //		ProviderId:      auth.Details().(security.ProviderDetails).ProviderId(),
 //		ProviderName:    auth.Details().(security.ProviderDetails).ProviderName(),

--- a/pkg/security/oauth2/auth/misc/check_token_claims.go
+++ b/pkg/security/oauth2/auth/misc/check_token_claims.go
@@ -33,7 +33,7 @@ type CheckTokenClaims struct {
 	AccountType     string          `claim:"account_type"`
 	Currency        string          `claim:"currency"`
 	TenantId        string          `claim:"tenant_id"`
-	TenantName      string          `claim:"tenant_name"`
+	TenantExternalId string          `claim:"tenant_name"` //This maps to Tenant's ExternalId for backward compatibility
 	TenantSuspended *bool           `claim:"tenant_suspended"`
 	ProviderId      string          `claim:"provider_id"`
 	ProviderName    string          `claim:"provider_name"`

--- a/pkg/security/oauth2/auth/openid/id_token.go
+++ b/pkg/security/oauth2/auth/openid/id_token.go
@@ -74,7 +74,7 @@ type IdTokenClaims struct {
 	UserId          string `claim:"user_id"`
 	AccountType     string `claim:"account_type"`
 	TenantId        string `claim:"tenant_id"`
-	TenantName      string `claim:"tenant_name"`
+	TenantExternalId      string `claim:"tenant_name"` //for backward compatibility, map to tenant_name
 	TenantSuspended *bool  `claim:"tenant_suspended"`
 	ProviderId      string `claim:"provider_id"`
 	ProviderName    string `claim:"provider_name"`

--- a/pkg/security/oauth2/auth/service.go
+++ b/pkg/security/oauth2/auth/service.go
@@ -320,8 +320,8 @@ func (s *DefaultAuthorizationService) loadTenant(ctx context.Context, request oa
 
 	// extract tenant id or name
 	tenantId, idOk := request.Parameters()[oauth2.ParameterTenantId]
-	tenantName, nOk := request.Parameters()[oauth2.ParameterTenantName]
-	if (!idOk || tenantId == "") && (!nOk || tenantName == "") {
+	tenantExternalId, nOk := request.Parameters()[oauth2.ParameterTenantExternalId]
+	if (!idOk || tenantId == "") && (!nOk || tenantExternalId == "") {
 		tenantId = acctT.DefaultDesignatedTenantId()
 	}
 
@@ -333,9 +333,9 @@ func (s *DefaultAuthorizationService) loadTenant(ctx context.Context, request oa
 			return nil, newInvalidTenantForUserError(fmt.Sprintf("user [%s] does not access tenant with id [%s]", account.Username(), tenantId))
 		}
 	} else {
-		tenant, e = s.tenantStore.LoadTenantByName(ctx, tenantName)
+		tenant, e = s.tenantStore.LoadTenantByExternalId(ctx, tenantExternalId)
 		if e != nil {
-			return nil, newInvalidTenantForUserError(fmt.Sprintf("user [%s] does not access tenant with name [%s]", account.Username(), tenantName))
+			return nil, newInvalidTenantForUserError(fmt.Sprintf("user [%s] does not access tenant with externalId [%s]", account.Username(), tenantExternalId))
 		}
 	}
 
@@ -381,7 +381,7 @@ func (s *DefaultAuthorizationService) loadProvider(ctx context.Context, _ oauth2
 
 	provider, e := s.providerStore.LoadProviderById(ctx, providerId)
 	if e != nil {
-		return nil, newInvalidProviderError(fmt.Sprintf("tenant [%s]'s provider is invalid", tenant.Name))
+		return nil, newInvalidProviderError(fmt.Sprintf("tenant [%s]'s provider is invalid", tenant.DisplayName))
 	}
 	return provider, nil
 }

--- a/pkg/security/oauth2/common/details_factory.go
+++ b/pkg/security/oauth2/common/details_factory.go
@@ -110,7 +110,7 @@ func (f *ContextDetailsFactory) create(ctx context.Context, facts *facts) (*inte
 	// tenant
 	td := internal.TenantDetails{
 		Id: facts.tenant.Id,
-		Name: facts.tenant.Name,
+		ExternalId: facts.tenant.ExternalId,
 		Suspended: facts.tenant.Suspended,
 	}
 

--- a/pkg/security/oauth2/common/internal/details_full.go
+++ b/pkg/security/oauth2/common/internal/details_full.go
@@ -14,7 +14,7 @@ type ProviderDetails struct {
 
 type TenantDetails struct {
 	Id        string
-	Name      string
+	ExternalId string
 	Suspended bool
 }
 
@@ -91,8 +91,8 @@ func (d *FullContextDetails) TenantId() string {
 }
 
 // security.TenantDetails
-func (d *FullContextDetails) TenantName() string {
-	return d.Tenant.Name
+func (d *FullContextDetails) TenantExternalId() string {
+	return d.Tenant.ExternalId
 }
 
 // security.TenantDetails

--- a/pkg/security/oauth2/constants.go
+++ b/pkg/security/oauth2/constants.go
@@ -22,7 +22,7 @@ const (
 	ParameterUsername            = "username"
 	ParameterPassword            = "password"
 	ParameterTenantId            = "tenant_id"
-	ParameterTenantName          = "tenant_name"
+	ParameterTenantExternalId          = "tenant_name" //for backward compatibility we map it to tenant_name
 	ParameterNonce               = "nonce"
 	ParameterMaxAge              = "max_age"
 	ParameterError               = "error"
@@ -164,7 +164,7 @@ const (
 	ClaimAccountType     = "account_type"
 	ClaimCurrency        = "currency"
 	ClaimTenantId        = "tenant_id"
-	ClaimTenantName      = "tenant_name"
+	ClaimTenantExternalId      = "tenant_name" //for backward compatibility we map it to tenant_name
 	ClaimTenantSuspended = "tenant_suspended"
 	ClaimProviderId      = "provider_id"
 	ClaimProviderName    = "provider_name"

--- a/test/sectest/examples/example_test.go
+++ b/test/sectest/examples/example_test.go
@@ -97,7 +97,7 @@ func SubTestExampleMockCurrentSecurity() test.GomegaSubTestFunc {
 			d.Username = "any-username"
 			d.UserId = "any-user-id"
 			d.TenantId = "any-tenant-id"
-			d.TenantName = "any-tenant-name"
+			d.TenantExternalId = "any-tenant-external-id"
 			d.Permissions = utils.NewStringSet(security.SpecialPermissionSwitchTenant)
 			// see sectest.SecurityDetailsMock for more options
 		})
@@ -115,7 +115,7 @@ func SubTestExampleMockBoth() test.GomegaSubTestFunc {
 			d.Username = "any-username"
 			d.UserId = "any-user-id"
 			d.TenantId = "any-tenant-id"
-			d.TenantName = "any-tenant-name"
+			d.TenantExternalId = "any-tenant-external-id"
 			d.Permissions = utils.NewStringSet(security.SpecialPermissionSwitchTenant)
 			// see sectest.SecurityDetailsMock for more options
 		})

--- a/test/sectest/mocks_account.go
+++ b/test/sectest/mocks_account.go
@@ -33,28 +33,28 @@ func newMockedAccount(props *mockedAccountProperties) *mockedAccount {
 	}
 	switch {
 	case ret.UserId == "":
-		ret.UserId = nameToId(ret.Username)
+		ret.UserId = extIdToId(ret.Username)
 	case ret.Username == "":
-		ret.Username = idToName(ret.UserId)
+		ret.Username = idToExtId(ret.UserId)
 	}
 	return ret
 }
 
 type mockedTenant struct {
-	Name string
+	ExternalId string
 	ID   string
 }
 
 func newMockedTenant(props *mockedTenantProperties) *mockedTenant {
 	ret := &mockedTenant{
-		Name: props.Name,
+		ExternalId: props.ExternalId,
 		ID:   props.ID,
 	}
 	switch {
 	case ret.ID == "":
-		ret.ID = nameToId(ret.Name)
-	case ret.Name == "":
-		ret.Name = idToName(ret.ID)
+		ret.ID = extIdToId(ret.ExternalId)
+	case ret.ExternalId == "":
+		ret.ExternalId = idToExtId(ret.ID)
 	}
 	return ret
 }
@@ -96,30 +96,30 @@ func (m mockedAccounts) idToName(id string) string {
 	if u, ok := m.idLookup[id]; ok {
 		return u.Username
 	}
-	return idToName(id)
+	return idToExtId(id)
 }
 
 func (m mockedAccounts) nameToId(name string) string {
 	if u, ok := m.lookup[name]; ok {
 		return u.UserId
 	}
-	return nameToId(name)
+	return extIdToId(name)
 }
 
 type mockedTenants struct {
 	idLookup map[string]*mockedTenant
-	nameLookup map[string]*mockedTenant
+	extIdLookup map[string]*mockedTenant
 }
 
 func newMockedTenants(props *mockingProperties) *mockedTenants {
 	tenants := mockedTenants{
 		idLookup: map[string]*mockedTenant{},
-		nameLookup:   map[string]*mockedTenant{},
+		extIdLookup:   map[string]*mockedTenant{},
 	}
 	for _, v := range props.Tenants {
 		t := newMockedTenant(v)
-		if t.Name != "" {
-			tenants.nameLookup[t.Name] = t
+		if t.ExternalId != "" {
+			tenants.extIdLookup[t.ExternalId] = t
 		}
 		if t.ID != "" {
 			tenants.idLookup[t.ID] = t
@@ -128,39 +128,39 @@ func newMockedTenants(props *mockingProperties) *mockedTenants {
 	return &tenants
 }
 
-func (m mockedTenants) find(tenantId, tenantName string) *mockedTenant {
-	if v, ok := m.idLookup[tenantId]; ok && (tenantName == "" || v.Name == tenantName) {
+func (m mockedTenants) find(tenantId, tenantExternalId string) *mockedTenant {
+	if v, ok := m.idLookup[tenantId]; ok && (tenantExternalId == "" || v.ExternalId == tenantExternalId) {
 		return v
 	}
 
-	if v, ok := m.nameLookup[tenantName]; ok && (tenantId == "" || v.ID == tenantId) {
+	if v, ok := m.extIdLookup[tenantExternalId]; ok && (tenantId == "" || v.ID == tenantId) {
 		return v
 	}
 	return nil
 }
 
-func (m mockedTenants) idToName(id string) string {
+func (m mockedTenants) idToExtId(id string) string {
 	if t, ok := m.idLookup[id]; ok {
-		return t.Name
+		return t.ExternalId
 	}
-	return idToName(id)
+	return idToExtId(id)
 }
 
-func (m mockedTenants) nameToId(name string) string {
-	if t, ok := m.nameLookup[name]; ok {
+func (m mockedTenants) extIdToId(name string) string {
+	if t, ok := m.extIdLookup[name]; ok {
 		return t.ID
 	}
-	return nameToId(name)
+	return extIdToId(name)
 }
 
 /*************************
 	Helpers
  *************************/
 
-func idToName(id string) string {
+func idToExtId(id string) string {
 	return strings.TrimPrefix(id, idPrefix)
 }
 
-func nameToId(name string) string {
-	return idPrefix + name
+func extIdToId(extId string) string {
+	return idPrefix + extId
 }

--- a/test/sectest/mocks_base.go
+++ b/test/sectest/mocks_base.go
@@ -55,7 +55,7 @@ func (b *mockedBase) newMockedToken(acct *mockedAccount, tenant *mockedTenant, e
 			UName: acct.Username,
 			UID:   acct.UserId,
 			TID:   tenant.ID,
-			TName: tenant.Name,
+			TExternalId: tenant.ExternalId,
 			OrigU: origUser,
 		},
 		ExpTime: exp,
@@ -87,7 +87,7 @@ func (b *mockedBase) newMockedAuth(mt *MockedToken, acct *mockedAccount) oauth2.
 		*d = SecurityDetailsMock{
 			Username:     mt.UName,
 			UserId:       mt.UID,
-			TenantName:   mt.TName,
+			TenantExternalId:   mt.TExternalId,
 			TenantId:     mt.TID,
 			Exp:          mt.ExpTime,
 			Iss:          mt.IssTime,

--- a/test/sectest/mocks_details.go
+++ b/test/sectest/mocks_details.go
@@ -11,7 +11,7 @@ type SecurityMockOptions func(d *SecurityDetailsMock)
 type SecurityDetailsMock struct {
 	Username     string
 	UserId       string
-	TenantName   string
+	TenantExternalId   string
 	TenantId     string
 	ProviderName string
 	ProviderId   string
@@ -89,8 +89,8 @@ func (d *mockedSecurityDetails) TenantId() string {
 	return d.SecurityDetailsMock.TenantId
 }
 
-func (d *mockedSecurityDetails) TenantName() string {
-	return d.SecurityDetailsMock.TenantName
+func (d *mockedSecurityDetails) TenantExternalId() string {
+	return d.SecurityDetailsMock.TenantExternalId
 }
 
 func (d *mockedSecurityDetails) TenantSuspended() bool {

--- a/test/sectest/mocks_properties.go
+++ b/test/sectest/mocks_properties.go
@@ -28,7 +28,7 @@ type mockedAccountProperties struct {
 
 type mockedTenantProperties struct {
 	ID   string `json:"id"` // optional field
-	Name string `json:"name"`
+	ExternalId string `json:"external-id"`
 }
 
 func bindMockingProperties(ctx *bootstrap.ApplicationContext) *mockingProperties {

--- a/test/sectest/mocks_seclient.go
+++ b/test/sectest/mocks_seclient.go
@@ -119,15 +119,15 @@ func (c *mockedAuthClient) option(opts []seclient.AuthOptions) (*seclient.AuthOp
 	if opt.UserId != "" && opt.Username != "" {
 		return nil, fmt.Errorf("[Mocked Error] username and userId are exclusive")
 	}
-	if opt.TenantId != "" && opt.TenantName != "" {
+	if opt.TenantId != "" && opt.TenantExternalId != "" {
 		return nil, fmt.Errorf("[Mocked Error] username and userId are exclusive")
 	}
 	return &opt, nil
 }
 
 func (c *mockedAuthClient) resolveTenant(opt *seclient.AuthOption, acct *mockedAccount) (ret *mockedTenant, err error) {
-	if opt.TenantId != "" || opt.TenantName != "" {
-		ret = c.tenants.find(opt.TenantId, opt.TenantName)
+	if opt.TenantId != "" || opt.TenantExternalId != "" {
+		ret = c.tenants.find(opt.TenantId, opt.TenantExternalId)
 	} else if acct.DefaultTenant != "" {
 		ret = c.tenants.find(acct.DefaultTenant, "")
 	}

--- a/test/sectest/mocks_token.go
+++ b/test/sectest/mocks_token.go
@@ -21,7 +21,7 @@ type MockedTokenInfo struct {
 	UName string
 	UID   string
 	TID   string
-	TName string
+	TExternalId string
 	OrigU string
 	Exp   int64
 	Iss   int64
@@ -58,7 +58,7 @@ func (mt *MockedToken) UnmarshalText(text []byte) error {
 }
 
 func (mt MockedToken) String() string {
-	vals := []string{mt.UName, mt.UID, mt.TID, mt.TName, mt.OrigU, mt.ExpTime.Format(utils.ISO8601Milliseconds)}
+	vals := []string{mt.UName, mt.UID, mt.TID, mt.TExternalId, mt.OrigU, mt.ExpTime.Format(utils.ISO8601Milliseconds)}
 	return strings.Join(vals, tokenDelimiter)
 }
 

--- a/test/sectest/scope_test.go
+++ b/test/sectest/scope_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultTenantId   = "id-tenant-1"
-	defaultTenantName = "tenant-1"
+	defaultTenantExternalId = "tenant-1"
 	systemUsername    = "system"
 	systemUserId      = "id-system"
 
@@ -26,9 +26,9 @@ const (
 	userId        = "id-regular"
 
 	tenantId      = "id-tenant-2"
-	tenantName    = "tenant-2"
+	tenantExternalId    = "tenant-2"
 	badTenantId   = "id-tenant-3"
-	badTenantName = "tenant-3"
+	badTenantExternalId = "tenant-3"
 
 	validity = 10 * time.Second
 )
@@ -65,7 +65,7 @@ func SubTestSysAcctLogin() test.GomegaSubTestFunc {
 			doAssertCurrentScope(ctx, g, "SysAcctLogin",
 				assertAuthenticated(),
 				assertWithUser(systemUsername, systemUserId),
-				assertWithTenant(defaultTenantId, defaultTenantName),
+				assertWithTenant(defaultTenantId, defaultTenantExternalId),
 				assertNotProxyAuth(),
 				assertValidityGreaterThan(validity),
 			)
@@ -82,7 +82,7 @@ func SubTestSysAcctWithTenant() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "SysAcct+TenantId",
 					assertAuthenticated(),
 					assertWithUser(systemUsername, systemUserId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
@@ -90,17 +90,17 @@ func SubTestSysAcctWithTenant() test.GomegaSubTestFunc {
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 		{
-			// use tenantName and existing auth
+			// use tenantExternalId and existing auth
 			ctx = WithMockedSecurity(ctx, securityMockRegular())
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "SysAcct+TenantName",
+				doAssertCurrentScope(ctx, g, "SysAcct+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(systemUsername, systemUserId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.UseSystemAccount(), scope.WithTenantName(tenantName))
+			}, scope.UseSystemAccount(), scope.WithTenantExternalId(tenantExternalId))
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 	}
@@ -116,7 +116,7 @@ func SubTestSwitchUserUsingSysAcct() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -130,7 +130,7 @@ func SubTestSwitchUserUsingSysAcct() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SysAcct+UserId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -148,7 +148,7 @@ func SubTestSwitchUserWithTenantUsingSysAcct() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username+TenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -159,14 +159,14 @@ func SubTestSwitchUserWithTenantUsingSysAcct() test.GomegaSubTestFunc {
 			// use tenent Name and existing auth
 			ctx = WithMockedSecurity(ctx, securityMockRegular())
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+SysAcct+Username+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(systemUsername),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.WithUserId(userId), scope.WithTenantName(tenantName), scope.UseSystemAccount())
+			}, scope.WithUserId(userId), scope.WithTenantExternalId(tenantExternalId), scope.UseSystemAccount())
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 	}
@@ -183,7 +183,7 @@ func SubTestSwitchUser() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+Username",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -196,7 +196,7 @@ func SubTestSwitchUser() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+UserId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(defaultTenantId, defaultTenantName),
+					assertWithTenant(defaultTenantId, defaultTenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -215,7 +215,7 @@ func SubTestSwitchUserWithTenant() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+Username+TenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
@@ -223,16 +223,16 @@ func SubTestSwitchUserWithTenant() test.GomegaSubTestFunc {
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 		{
-			// use tenantName
+			// use tenantExternalId
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+Username+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+Username+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertProxyAuth(adminUsername),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.WithUsername(username), scope.WithTenantName(tenantName))
+			}, scope.WithUsername(username), scope.WithTenantExternalId(tenantExternalId))
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 
@@ -250,7 +250,7 @@ func SubTestSwitchTenant() test.GomegaSubTestFunc {
 				doAssertCurrentScope(ctx, g, "Switch+TenantId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
@@ -258,16 +258,16 @@ func SubTestSwitchTenant() test.GomegaSubTestFunc {
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 		{
-			// use tenantName
+			// use tenantExternalId
 			e := scope.Do(ctx, func(ctx context.Context) {
-				doAssertCurrentScope(ctx, g, "Switch+TenantName",
+				doAssertCurrentScope(ctx, g, "Switch+TenantExternalId",
 					assertAuthenticated(),
 					assertWithUser(username, userId),
-					assertWithTenant(tenantId, tenantName),
+					assertWithTenant(tenantId, tenantExternalId),
 					assertNotProxyAuth(),
 					assertValidityGreaterThan(validity),
 				)
-			}, scope.WithTenantName(tenantName))
+			}, scope.WithTenantExternalId(tenantExternalId))
 			g.Expect(e).To(Succeed(), "scope manager shouldn't returns error")
 		}
 	}
@@ -288,10 +288,10 @@ func SubTestSwitchWithError() test.GomegaSubTestFunc {
 		}
 
 		{
-			// use tenantName
+			// use tenantExternalId
 			e := scope.Do(ctx, func(ctx context.Context) {
 				t.Errorf("scoped function should be be invoked in case of error")
-			}, scope.WithTenantName(badTenantName))
+			}, scope.WithTenantExternalId(badTenantExternalId))
 
 			g.Expect(e).To(Not(Succeed()), "scope manager should returns error")
 		}
@@ -341,7 +341,7 @@ func assertWithTenant(id, name string) assertion {
 		}
 
 		if name != "" {
-			g.Expect(details.TenantName()).To(Equal(name), "[%s] should authenticated as tenant name [%s]", msg, name)
+			g.Expect(details.TenantExternalId()).To(Equal(name), "[%s] should authenticated as tenant name [%s]", msg, name)
 		}
 	}
 }
@@ -381,7 +381,7 @@ func securityMockAdmin() SecurityMockOptions {
 		d.Username = adminUsername
 		d.UserId = adminUserId
 		d.TenantId = defaultTenantId
-		d.TenantName = defaultTenantName
+		d.TenantExternalId = defaultTenantExternalId
 		d.Permissions = utils.NewStringSet(
 			security.SpecialPermissionSwitchUser,
 			security.SpecialPermissionSwitchTenant)
@@ -393,7 +393,7 @@ func securityMockRegular() SecurityMockOptions {
 		d.Username = username
 		d.UserId = userId
 		d.TenantId = defaultTenantId
-		d.TenantName = defaultTenantName
+		d.TenantExternalId = defaultTenantExternalId
 		d.Permissions = utils.NewStringSet(security.SpecialPermissionSwitchTenant)
 	}
 }

--- a/test/sectest/security.go
+++ b/test/sectest/security.go
@@ -25,7 +25,7 @@ func WithMockedSecurity(ctx context.Context, opts...SecurityMockOptions) context
 			UName: details.Username(),
 			UID:   details.UserId(),
 			TID:   details.TenantId(),
-			TName: details.TenantName(),
+			TExternalId: details.TenantExternalId(),
 			OrigU: details.OrigUsername,
 		},
 		ExpTime:         details.Exp,

--- a/test/sectest/test-scopes.yml
+++ b/test/sectest/test-scopes.yml
@@ -34,10 +34,10 @@ mocking:
   tenants:
     t1:
       id: "id-tenant-1"
-      name: "tenant-1"
+      external-id: "tenant-1"
     t2:
       id: "id-tenant-2"
-      name: "tenant-2"
+      external-id: "tenant-2"
     t3:
       id: "id-tenant-3"
-      name: "tenant-3"
+      external-id: "tenant-3"


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-10-08T19:15:53Z" title="Friday, October 8th 2021, 3:15:53 pm -04:00">Oct 8, 2021</time>_
_Merged <time datetime="2021-10-08T20:20:14Z" title="Friday, October 8th 2021, 4:20:14 pm -04:00">Oct 8, 2021</time>_
---

Because in the tenant model we have renamed the old "name" column to be "externalId". So internally in security, we should use tenant.externalId where we used to have tenant name in Java implementation. 