### PR TITLE
make cookie path configurable

### DIFF
--- a/pkg/security/properties.go
+++ b/pkg/security/properties.go
@@ -28,6 +28,7 @@ type CookieProperties struct {
 	Secure         bool   `json:"secure"`
 	HttpOnly       bool   `json:"http-only"`
 	SameSiteString string `json:"same-site"`
+	Path           string `json:"path"`
 }
 
 func (cp CookieProperties) SameSite() http.SameSite {
@@ -48,6 +49,7 @@ func NewSessionProperties() *SessionProperties {
 	return &SessionProperties {
 		Cookie: CookieProperties{
 			HttpOnly: true,
+			Path: "/",
 		},
 		IdleTimeout: utils.Duration(900 * time.Second),
 		AbsoluteTimeout: utils.Duration(1800 * time.Second),

--- a/pkg/security/session/package.go
+++ b/pkg/security/session/package.go
@@ -61,7 +61,7 @@ func provideSessionStore(di storeDI) Store {
 	return NewRedisStore(redisClient, func(opt *StoreOption) {
 		opt.SettingReader = di.SettingReader
 
-		opt.Options.Path = path.Clean("/" + di.ServerProps.ContextPath)
+		opt.Options.Path = path.Clean(di.SessionProps.Cookie.Path)
 		opt.Options.Domain = di.SessionProps.Cookie.Domain
 		opt.Options.MaxAge = di.SessionProps.Cookie.MaxAge
 		opt.Options.Secure = di.SessionProps.Cookie.Secure


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-11-17T18:57:36Z" title="Wednesday, November 17th 2021, 1:57:36 pm -05:00">Nov 17, 2021</time>_
_Merged <time datetime="2021-11-17T21:57:08Z" title="Wednesday, November 17th 2021, 4:57:08 pm -05:00">Nov 17, 2021</time>_
---

Make cookie path configurable and by default set it to "/"

We need to set it to "/" instead of "auth", because from outside of router we still support the /idm path. So some apps like Kibana is still going to send auth request to /idm. So setting cookie path to "/" by default allows cookie to be sent along with those requests. 