### PR TITLE
switched order of sso location in saml metadata

### DIFF
--- a/pkg/security/saml/saml_sso/middleware.go
+++ b/pkg/security/saml/saml_sso/middleware.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"net/url"
+	"sort"
 )
 
 type Options struct {
@@ -204,6 +205,10 @@ func (mw *SamlAuthorizeEndpointMiddleware) RefreshMetadataHandler(condition web.
 func (mw *SamlAuthorizeEndpointMiddleware) MetadataHandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		metadata := mw.idp.Metadata()
+		sort.SliceStable(metadata.IDPSSODescriptors[0].SingleSignOnServices, func(i, j int) bool {
+			return metadata.IDPSSODescriptors[0].SingleSignOnServices[i].Binding < metadata.IDPSSODescriptors[0].SingleSignOnServices[j].Binding
+		})
+
 		var t = true
 		//We always want the authentication request to be signed
 		//But because this is not supported by the saml package, we set it here explicitly

--- a/pkg/security/saml/saml_sso/middleware_test.go
+++ b/pkg/security/saml/saml_sso/middleware_test.go
@@ -196,11 +196,11 @@ func (m MetadataMatcher) Match(actual interface{}) (success bool, err error) {
 		return false, nil
 	}
 
-	if descriptor.IDPSSODescriptors[0].SingleSignOnServices[0].Binding != saml.HTTPRedirectBinding || descriptor.IDPSSODescriptors[0].SingleSignOnServices[0].Location != "http://vms.com:8080/europa/v2/authorize?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer"{
+	if descriptor.IDPSSODescriptors[0].SingleSignOnServices[0].Binding != saml.HTTPPostBinding || descriptor.IDPSSODescriptors[0].SingleSignOnServices[0].Location != "http://vms.com:8080/europa/v2/authorize?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer"{
 		return false, nil
 	}
 
-	if descriptor.IDPSSODescriptors[0].SingleSignOnServices[1].Binding != saml.HTTPPostBinding || descriptor.IDPSSODescriptors[0].SingleSignOnServices[1].Location != "http://vms.com:8080/europa/v2/authorize?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer" {
+	if descriptor.IDPSSODescriptors[0].SingleSignOnServices[1].Binding != saml.HTTPRedirectBinding || descriptor.IDPSSODescriptors[0].SingleSignOnServices[1].Location != "http://vms.com:8080/europa/v2/authorize?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer" {
 		return false, nil
 	}
 


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2021-12-15T22:13:54Z" title="Wednesday, December 15th 2021, 5:13:54 pm -05:00">Dec 15, 2021</time>_
_Merged <time datetime="2021-12-17T21:23:39Z" title="Friday, December 17th 2021, 4:23:39 pm -05:00">Dec 17, 2021</time>_
---

Did this as a work around to make integration with vManaage easier until they fixed their bug.

Originally, in the metdata file, we advertise these two bindings

```
<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8900/auth/v2/authorize?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer"/>
<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8900/auth/v2/authorize?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer"/>
```

The Http-Redirect comes first, so vManage uses it by default.  But they have a bug where they dropped grant_type parameter from the request. However, they handle the Http-Post binding properly.

So re-arrange the order to save the Opts team some trouble of manually editing the metadata file until they resolve the issue on their end.