### PR TITLE
DE14085 disable idle timeout or absolute time out if they are set to zero or negative value

### DIFF
--- a/pkg/security/session/common/context.go
+++ b/pkg/security/session/common/context.go
@@ -1,6 +1,9 @@
 package common
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 const RedisNameSpace = "LANAI:SESSION" //This is to avoid confusion with records from other frameworks.
 const SessionLastAccessedField = "lastAccessed"
@@ -8,6 +11,31 @@ const SessionIdleTimeoutDuration = "idleTimeout"
 const SessionAbsTimeoutTime = "absTimeout"
 const DefaultName = "SESSION"
 
+type TimeoutSetting int
+
+const (
+	IdleTimeoutEnabled     TimeoutSetting = 1 << iota
+	AbsoluteTimeoutEnabled TimeoutSetting = 1 << iota
+)
+
 func GetRedisSessionKey(name string, id string) string {
 	return fmt.Sprintf("%s:%s:%s", RedisNameSpace, name, id)
+}
+
+func CalculateExpiration(setting TimeoutSetting, idleExpiration time.Time, absExpiration time.Time) (canExpire bool, expiration time.Time) {
+	switch setting {
+	case AbsoluteTimeoutEnabled:
+		return true, absExpiration
+	case IdleTimeoutEnabled:
+		return true, idleExpiration
+	case AbsoluteTimeoutEnabled | IdleTimeoutEnabled:
+		//whichever is the earliest
+		if idleExpiration.Before(absExpiration) {
+			return true, idleExpiration
+		} else {
+			return true, absExpiration
+		}
+	default:
+		return false, time.Time{}
+	}
 }

--- a/pkg/security/session/session_test.go
+++ b/pkg/security/session/session_test.go
@@ -118,3 +118,108 @@ func TestExpiration(t *testing.T) {
 		t.Errorf("created at %v, last accessed at %v should be valid", s.values[createdTimeKey], s.lastAccessed)
 	}
 }
+
+//TODO: add test scenario for when idle time out is not enabled, abs timeout is not enabled, both not enabled
+
+func TestIdleTimeoutDisabled(t *testing.T) {
+	s := &Session{
+		values: make(map[interface{}]interface{}),
+		name:   "session-key",
+		options: &Options{
+			IdleTimeout: 0,
+			AbsoluteTimeout: 1800 * time.Second,
+		},
+		isNew: true,
+		dirty: false,
+	}
+
+	//just created session should not be expired
+	s.lastAccessed = time.Now()
+	s.values[createdTimeKey] = time.Now()
+
+	if s.isExpired() {
+		t.Errorf("just created session should not be expired")
+	}
+
+	//test scenario for a absolute timeout
+	s.lastAccessed = time.Now().Add(-450 * time.Second)
+	s.values[createdTimeKey] = time.Now().Add(-1801 * time.Second)
+
+	if !s.isExpired() {
+		t.Errorf("created at %v, with abs timeout %v should be expired", s.values[createdTimeKey], s.options.AbsoluteTimeout)
+	}
+
+	//test scenario for a not expired session
+	s.lastAccessed = time.Now().Add(-450 * time.Second)
+	s.values[createdTimeKey] = time.Now().Add(-1700 * time.Second)
+
+	if s.isExpired() {
+		t.Errorf("created at %v, last accessed at %v should be valid", s.values[createdTimeKey], s.lastAccessed)
+	}
+}
+
+func TestAbsTimeoutDisabled(t *testing.T) {
+	s := &Session{
+		values: make(map[interface{}]interface{}),
+		name:   "session-key",
+		options: &Options{
+			IdleTimeout: 900 * time.Second,
+			AbsoluteTimeout: 0 * time.Second,
+		},
+		isNew: true,
+		dirty: false,
+	}
+
+	//just created session should not be expired
+	s.lastAccessed = time.Now()
+	s.values[createdTimeKey] = time.Now()
+
+	if s.isExpired() {
+		t.Errorf("just created session should not be expired")
+	}
+
+	//test scenario for a idle timeout
+	s.lastAccessed = time.Now().Add(-901 * time.Second)
+	s.values[createdTimeKey] = time.Now().Add(-901 * time.Second)
+
+	if !s.isExpired() {
+		t.Errorf("last accessed at %v, with idle timeout %v should be expired", s.lastAccessed, s.options.IdleTimeout)
+	}
+
+	//test scenario for a not expired session
+	s.lastAccessed = time.Now().Add(-450 * time.Second)
+	s.values[createdTimeKey] = time.Now().Add(-800 * time.Second)
+
+	if s.isExpired() {
+		t.Errorf("created at %v, last accessed at %v should be valid", s.values[createdTimeKey], s.lastAccessed)
+	}
+}
+
+func TestBothTimeoutDisabled(t *testing.T) {
+	s := &Session{
+		values: make(map[interface{}]interface{}),
+		name:   "session-key",
+		options: &Options{
+			IdleTimeout: 0 * time.Second,
+			AbsoluteTimeout: 0 * time.Second,
+		},
+		isNew: true,
+		dirty: false,
+	}
+
+	//just created session should not be expired
+	s.lastAccessed = time.Now()
+	s.values[createdTimeKey] = time.Now()
+
+	if s.isExpired() {
+		t.Errorf("just created session should not be expired")
+	}
+
+	//session should not expired
+	s.lastAccessed = time.Now().Add(-1000 * time.Second)
+	s.values[createdTimeKey] = time.Now().Add(-2000 * time.Second)
+
+	if s.isExpired() {
+		t.Errorf("created at %v, last accessed at %v should be valid", s.values[createdTimeKey], s.lastAccessed)
+	}
+}


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2022-03-14T18:02:01Z" title="Monday, March 14th 2022, 2:02:01 pm -04:00">Mar 14, 2022</time>_
_Merged <time datetime="2022-03-14T20:14:03Z" title="Monday, March 14th 2022, 4:14:03 pm -04:00">Mar 14, 2022</time>_
---

if either timeout is set to a negative value, treat that time out as being disabled. This is to make the behavior consistent with Java/Spring