### PR TITLE
DE14345 migrations failed with non root user

### DIFF
--- a/pkg/data/cockroach/db_creator.go
+++ b/pkg/data/cockroach/db_creator.go
@@ -8,16 +8,23 @@ import (
 )
 
 type GormDbCreator struct {
+	dbUser string
 	dbName string
 }
 
 func NewGormDbCreator(properties CockroachProperties) data.DbCreator {
 	return &GormDbCreator{
+		dbUser: properties.Username,
 		dbName: properties.Database,
 	}
 }
 
 func (g *GormDbCreator) CreateDatabaseIfNotExist(ctx context.Context, db *gorm.DB) error {
+	if g.dbUser != "root" {
+		logger.WithContext(ctx).Info("db user is not a privileged account, skipped db creation.")
+		return nil
+	}
 	result := db.WithContext(ctx).Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", g.dbName))
 	return result.Error
+
 }


### PR DESCRIPTION
> [<img alt="xinzlu" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/xinzlu) **Authored by [xinzlu](https://cto-github.cisco.com/xinzlu)**
_<time datetime="2022-03-25T21:15:01Z" title="Friday, March 25th 2022, 5:15:01 pm -04:00">Mar 25, 2022</time>_
_Merged <time datetime="2022-03-25T22:56:19Z" title="Friday, March 25th 2022, 6:56:19 pm -04:00">Mar 25, 2022</time>_
---

db creation failed when the db is managed by infra.
```
2022-03-24T19:35:15.786Z   INFO [       package.go:91]    Bootstrap: [] Stopped usermanagementgoservice in 0s 
2022-03-24T19:35:15.786Z  ERROR [ bootstrapper.go:178]    Bootstrap: [] Shutdown with Error: ERROR: permission denied to create database (SQLSTATE 42501) 
```
followed the same pattern in go-msx
https://cto-github.cisco.com/NFV-BU/go-msx/blob/7d41f088d2e8741890189f1b597ec045859c3c31/sqldb/pool.go#L139