### PR TITLE
Feature/thousand eyes

### DIFF
--- a/pkg/security/saml/saml_sso/assertion.go
+++ b/pkg/security/saml/saml_sso/assertion.go
@@ -78,6 +78,19 @@ func MakeAssertion(ctx context.Context, req *saml.IdpAuthnRequest, authenticatio
 		}
 	}
 
+	var nameId *saml.NameID
+	if acct != nil {
+		nameId = &saml.NameID{
+			Format:          "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+			Value:           acct.(security.AccountMetadata).Email(),
+		}
+	} else {
+		nameId = &saml.NameID{
+			Format:          "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+			Value:           username,
+		}
+	}
+
 	req.Assertion = &saml.Assertion{
 		ID:           fmt.Sprintf("id-%x", cryptoutils.RandomBytes(20)),
 		IssueInstant: saml.TimeNow(),
@@ -87,10 +100,7 @@ func MakeAssertion(ctx context.Context, req *saml.IdpAuthnRequest, authenticatio
 			Value:  req.IDP.Metadata().EntityID,
 		},
 		Subject: &saml.Subject{
-			NameID: &saml.NameID{
-				Format:          "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-				Value:           acct.(security.AccountMetadata).Email(),
-			},
+			NameID: nameId,
 			SubjectConfirmations: []saml.SubjectConfirmation{
 				{
 					Method: "urn:oasis:names:tc:SAML:2.0:cm:bearer",

--- a/test/sectest/mocks_account.go
+++ b/test/sectest/mocks_account.go
@@ -14,7 +14,7 @@ const (
 	Account & Tenant
  *************************/
 
-type mockedAccount struct {
+type MockedAccount struct {
 	UserId          string
 	username        string
 	Password        string
@@ -22,58 +22,87 @@ type mockedAccount struct {
 	DefaultTenant   string
 	AssignedTenants utils.StringSet
 	permissions     utils.StringSet
+	UserEmail 		string
 }
 
-func (m *mockedAccount) DefaultDesignatedTenantId() string {
+func (m *MockedAccount) RoleNames() []string {
+	panic("implement me")
+}
+
+func (m *MockedAccount) FirstName() string {
+	panic("implement me")
+}
+
+func (m *MockedAccount) LastName() string {
+	panic("implement me")
+}
+
+func (m *MockedAccount) Email() string {
+	return m.UserEmail
+}
+
+func (m *MockedAccount) LocaleCode() string {
+	panic("implement me")
+}
+
+func (m *MockedAccount) CurrencyCode() string {
+	panic("implement me")
+}
+
+func (m *MockedAccount) Value(key string) interface{} {
+	panic("implement me")
+}
+
+func (m *MockedAccount) DefaultDesignatedTenantId() string {
 	return m.DefaultTenant
 }
 
-func (m *mockedAccount) DesignatedTenantIds() []string {
+func (m *MockedAccount) DesignatedTenantIds() []string {
 	return m.AssignedTenants.Values()
 }
 
-func (m *mockedAccount) TenantId() string {
+func (m *MockedAccount) TenantId() string {
 	return m.tenantId
 }
 
-func (m *mockedAccount) ID() interface{} {
+func (m *MockedAccount) ID() interface{} {
 	return m.UserId
 }
 
-func (m *mockedAccount) Type() security.AccountType {
+func (m *MockedAccount) Type() security.AccountType {
 	panic("implement me")
 }
 
-func (m *mockedAccount) Username() string {
+func (m *MockedAccount) Username() string {
 	return m.username
 }
 
-func (m *mockedAccount) Credentials() interface{} {
+func (m *MockedAccount) Credentials() interface{} {
 	panic("implement me")
 }
 
-func (m *mockedAccount) Permissions() []string {
+func (m *MockedAccount) Permissions() []string {
 	return m.permissions.Values()
 }
 
-func (m mockedAccount) Disabled() bool {
+func (m MockedAccount) Disabled() bool {
 	panic("implement me")
 }
 
-func (m mockedAccount) Locked() bool {
+func (m MockedAccount) Locked() bool {
 	panic("implement me")
 }
 
-func (m mockedAccount) UseMFA() bool {
+func (m MockedAccount) UseMFA() bool {
 	panic("implement me")
 }
 
-func (m mockedAccount) CacheableCopy() security.Account {
+func (m MockedAccount) CacheableCopy() security.Account {
 	panic("implement me")
 }
 
-func newMockedAccount(props *MockedAccountProperties) *mockedAccount {
-	ret := &mockedAccount{
+func newMockedAccount(props *MockedAccountProperties) *MockedAccount {
+	ret := &MockedAccount{
 		UserId:          props.UserId,
 		username:        props.Username,
 		Password:        props.Password,
@@ -110,14 +139,14 @@ func newMockedTenant(props *mockedTenantProperties) *mockedTenant {
 }
 
 type mockedAccounts struct {
-	idLookup map[string]*mockedAccount
-	lookup   map[string]*mockedAccount
+	idLookup map[string]*MockedAccount
+	lookup   map[string]*MockedAccount
 }
 
 func newMockedAccounts(props *mockingProperties) *mockedAccounts {
 	accts := mockedAccounts{
-		idLookup: map[string]*mockedAccount{},
-		lookup:   map[string]*mockedAccount{},
+		idLookup: map[string]*MockedAccount{},
+		lookup:   map[string]*MockedAccount{},
 	}
 	for _, v := range props.Accounts {
 		acct := newMockedAccount(v)
@@ -131,7 +160,7 @@ func newMockedAccounts(props *mockingProperties) *mockedAccounts {
 	return &accts
 }
 
-func (m mockedAccounts) find(username, userId string) *mockedAccount {
+func (m mockedAccounts) find(username, userId string) *MockedAccount {
 	if v, ok := m.lookup[username]; ok && (userId == "" || v.UserId == userId) {
 		return v
 	}

--- a/test/sectest/mocks_account_store.go
+++ b/test/sectest/mocks_account_store.go
@@ -7,14 +7,14 @@ import (
 )
 
 type MockAccountStore struct {
-	accountLookupByUsername map[string]*mockedAccount
-	accountLookupById       map[interface{}]*mockedAccount
+	accountLookupByUsername map[string]*MockedAccount
+	accountLookupById       map[interface{}]*MockedAccount
 }
 
 func NewMockedAccountStore(props... *MockedAccountProperties) *MockAccountStore {
 	store := &MockAccountStore{
-		accountLookupById: make(map[interface{}]*mockedAccount),
-		accountLookupByUsername: make(map[string]*mockedAccount),
+		accountLookupById: make(map[interface{}]*MockedAccount),
+		accountLookupByUsername: make(map[string]*MockedAccount),
 	}
 	for _, v := range props {
 		acct := newMockedAccount(v)

--- a/test/sectest/mocks_auth_middleware.go
+++ b/test/sectest/mocks_auth_middleware.go
@@ -26,14 +26,14 @@ func (m *MockAuthenticationMiddleware) AuthenticationHandlerFunc() gin.HandlerFu
 type MockUserAuthOptions func(opt *MockUserAuthOption)
 
 type MockUserAuthOption struct {
-	Principal   string
+	Principal   interface{}
 	Permissions map[string]interface{}
 	State       security.AuthenticationState
 	Details     interface{}
 }
 
 type mockUserAuthentication struct {
-	Subject       string
+	Subject       interface{}
 	PermissionMap map[string]interface{}
 	StateValue    security.AuthenticationState
 	details       interface{}

--- a/test/sectest/mocks_base.go
+++ b/test/sectest/mocks_base.go
@@ -49,7 +49,7 @@ func (b *mockedBase) isTokenRevoked(token *MockedToken, value string) bool {
 	return token.IssTime.Before(b.notBefore) || b.revoked.Has(value)
 }
 
-func (b *mockedBase) newMockedToken(acct *mockedAccount, tenant *mockedTenant, exp time.Time, origUser string) *MockedToken {
+func (b *mockedBase) newMockedToken(acct *MockedAccount, tenant *mockedTenant, exp time.Time, origUser string) *MockedToken {
 	return &MockedToken{
 		MockedTokenInfo: MockedTokenInfo{
 			UName: acct.username,
@@ -74,7 +74,7 @@ func (b *mockedBase) parseMockedToken(value string) (*MockedToken, error) {
 	return mt, nil
 }
 
-func (b *mockedBase) newMockedAuth(mt *MockedToken, acct *mockedAccount) oauth2.Authentication {
+func (b *mockedBase) newMockedAuth(mt *MockedToken, acct *MockedAccount) oauth2.Authentication {
 	user := oauth2.NewUserAuthentication(func(opt *oauth2.UserAuthOption) {
 		opt.Principal = mt.UName
 		opt.State = security.StateAuthenticated

--- a/test/sectest/mocks_seclient.go
+++ b/test/sectest/mocks_seclient.go
@@ -125,7 +125,7 @@ func (c *mockedAuthClient) option(opts []seclient.AuthOptions) (*seclient.AuthOp
 	return &opt, nil
 }
 
-func (c *mockedAuthClient) resolveTenant(opt *seclient.AuthOption, acct *mockedAccount) (ret *mockedTenant, err error) {
+func (c *mockedAuthClient) resolveTenant(opt *seclient.AuthOption, acct *MockedAccount) (ret *mockedTenant, err error) {
 	if opt.TenantId != "" || opt.TenantExternalId != "" {
 		ret = c.tenants.find(opt.TenantId, opt.TenantExternalId)
 	} else if acct.DefaultTenant != "" {


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2022-06-03T21:44:27Z" title="Friday, June 3rd 2022, 5:44:27 pm -04:00">Jun 3, 2022</time>_
_Closed <time datetime="2022-09-26T15:00:27Z" title="Monday, September 26th 2022, 11:00:27 am -04:00">Sep 26, 2022</time>_
---

For thousand eye SSO integration, it requires nameID to be email address. Tested this change and it works with other existing saml service providers as well (vManage, Meraki). So this works for the mean time.

I also created a feature in rally to allow each service provider to configure its own assertion attributes.