### PR TITLE
DE15138 Fix empty tags appearing in consul

### DIFF
--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -16,6 +16,7 @@ import (
 var (
 	logger = log.New("Config")
 	//ErrNotLoaded = errors.New("Configuration not loaded")
+	errBindWithConfigBeforeLoaded = errors.New("attempt to bind with config before it's loaded")
 )
 
 // properties implements bootstrap.ApplicationConfig
@@ -186,7 +187,7 @@ func (c *config) Value(key string) interface{} {
 
 func (c *config) Bind(target interface{}, prefix string) error {
 	if !c.isLoaded {
-		return fmt.Errorf("attempt to bind with config before it's loaded loaded ")
+		return errBindWithConfigBeforeLoaded
 	}
 	return c.properties.Bind(target, prefix)
 }

--- a/pkg/utils/slice.go
+++ b/pkg/utils/slice.go
@@ -45,6 +45,9 @@ func (s CommaSeparatedSlice) MarshalText() ([]byte, error) {
 
 // UnmarshalText encoding.TextUnmarshaler
 func (s *CommaSeparatedSlice) UnmarshalText(data []byte) error {
+	if string(data) == "" {
+		return nil
+	}
 	var result []string
 	split := strings.Split(string(data), ",")
 	for _, s := range split {
@@ -71,7 +74,3 @@ func (s *CommaSeparatedSlice) UnmarshalJSON(data []byte) error {
 	}
 	return s.UnmarshalText([]byte(str))
 }
-
-
-
-

--- a/pkg/utils/slice_test.go
+++ b/pkg/utils/slice_test.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommaSeparatedSlice_UnmarshalText(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name     string
+		s        CommaSeparatedSlice
+		args     args
+		expected CommaSeparatedSlice
+		wantErr  bool
+	}{
+		{
+			name: "UnmarshalText should separate text into comma seperated slices",
+			s:    CommaSeparatedSlice{},
+			args: args{data: []byte("hello, world")},
+			expected: CommaSeparatedSlice{
+				"hello",
+				"world",
+			},
+			wantErr: false,
+		},
+		{
+			name: "UnmarshalText should trim leading/trailing spaces from input",
+			s:    CommaSeparatedSlice{},
+			args: args{data: []byte("trailing , leading, leading and trailing ")},
+			expected: CommaSeparatedSlice{
+				"trailing",
+				"leading",
+				"leading and trailing",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "UnmarshalText should return empty slice if provided empty string",
+			s:        CommaSeparatedSlice{},
+			args:     args{data: []byte("")},
+			expected: CommaSeparatedSlice{},
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.s.UnmarshalText(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalText() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.s, tt.expected) {
+				t.Errorf("Failed: expected %v, got %v", tt.expected, tt.s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> [<img alt="biluu" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/biluu) **Authored by [biluu](https://cto-github.cisco.com/biluu)**
_<time datetime="2022-07-27T20:09:13Z" title="Wednesday, July 27th 2022, 4:09:13 pm -04:00">Jul 27, 2022</time>_
_Merged <time datetime="2022-07-28T16:07:21Z" title="Thursday, July 28th 2022, 12:07:21 pm -04:00">Jul 28, 2022</time>_
---

This was due to `${spring.cloud.consul.discovery.tags:}` from default-discovery.yml evaluating to the default value of just "". which gets added to the CommaSeperatedSlice as just `[""]`. Updated the unmarhsaling so that it would process "" as `[]` instead.

Before:
![image](https://cto-github.cisco.com/storage/user/9566/files/33cb55c1-a9c9-4ab8-bde5-3dc19645a5b0)

After:
![image](https://cto-github.cisco.com/storage/user/9566/files/c48c4438-9146-4778-9abf-893ecd7bb194)

DE15138