### PR TITLE
Export the Before and After in TracingProvider for opensearch

### DIFF
--- a/pkg/tracing/instrument/opensearch.go
+++ b/pkg/tracing/instrument/opensearch.go
@@ -65,14 +65,14 @@ func OpenSearchTracerHook(tracer opentracing.Tracer) *OpenSearchTracer {
 type TracingProvider struct {
 	fx.Out
 
-	before opensearch.BeforeHook `group:"opensearchbeforehooks"`
-	after  opensearch.AfterHook  `group:"opensearchafterhooks"`
+	Before opensearch.BeforeHook `group:"opensearch_before_hooks"`
+	After  opensearch.AfterHook  `group:"opensearch_after_hooks"`
 }
 
 func OpenSearchTracingProvider(tracer opentracing.Tracer) TracingProvider {
 	tracerHook := OpenSearchTracerHook(tracer)
 	return TracingProvider{
-		before: tracerHook,
-		after:  tracerHook,
+		Before: tracerHook,
+		After:  tracerHook,
 	}
 }


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2022-09-06T17:43:01Z" title="Tuesday, September 6th 2022, 1:43:01 pm -04:00">Sep 6, 2022</time>_
_Merged <time datetime="2022-09-06T17:52:58Z" title="Tuesday, September 6th 2022, 1:52:58 pm -04:00">Sep 6, 2022</time>_
---

Checked locally that usermanagement does not run with the current `develop` branch.

After the fixes here, usermanagment is able to run again. 