### PR TITLE
US40776: Added `ccv precheck` target to Makefile

### DIFF
--- a/cmd/lanai-cli/initcmd/Makefile-Build.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile-Build.tmpl
@@ -95,3 +95,7 @@ $(GEN_LIST):
 resource@{{ .Output }}:
 	cp -rf {{ .Pattern }} $(DESTDIR)/{{ .Output }}
 	{{ end }}
+
+# Runs contract-verifier precheck to verify service contract against CPX guidelines
+contract:
+	ccv precheck

--- a/cmd/lanai-cli/initcmd/Makefile-CICD.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile-CICD.tmpl
@@ -47,7 +47,7 @@ report: test
 #	Example:
 # 		make verify PRIVATE_MODS=cto-github.cisco.com/NFV-BU/go-lanai@develop
 verify: SAVEPOINT_MARK = tmp/pre-verify
-verify: pre-verify clean test lint build report post-verify
+verify: pre-verify clean test lint build report contract post-verify
 
 # dist:
 #	Make a distribution build with provided PRIVATE_MODS and VERSION,

--- a/cmd/lanai-cli/initcmd/binaries.go
+++ b/cmd/lanai-cli/initcmd/binaries.go
@@ -2,17 +2,19 @@ package initcmd
 
 import (
 	"context"
-	"cto-github.cisco.com/NFV-BU/go-lanai/cmd/lanai-cli/cmdutils"
 	"fmt"
 	"os"
+
+	"cto-github.cisco.com/NFV-BU/go-lanai/cmd/lanai-cli/cmdutils"
 )
 
 var defaultBinaries = map[string]string{
-	"github.com/axw/gocov/gocov":                          "v1.1.0",
-	"github.com/AlekSi/gocov-xml":                         "v1.0.0",
-	"gotest.tools/gotestsum":                              "v1.8.0",
-	"github.com/golangci/golangci-lint/cmd/golangci-lint": "v1.49.0",
-	"github.com/jstemmer/go-junit-report":                 "v0.9.1",
+	"github.com/axw/gocov/gocov":                            "v1.1.0",
+	"github.com/AlekSi/gocov-xml":                           "v1.0.0",
+	"gotest.tools/gotestsum":                                "v1.8.0",
+	"github.com/golangci/golangci-lint/cmd/golangci-lint":   "v1.49.0",
+	"github.com/jstemmer/go-junit-report":                   "v0.9.1",
+	"cto-github.cisco.com/NFV-BU/contract-verifier/cli/ccv": "latest",
 }
 
 func installBinaries(ctx context.Context) error {


### PR DESCRIPTION
> [<img alt="sumangat" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/sumangat) **Authored by [sumangat](https://cto-github.cisco.com/sumangat)**
_<time datetime="2022-09-19T22:26:49Z" title="Monday, September 19th 2022, 6:26:49 pm -04:00">Sep 19, 2022</time>_
_Merged <time datetime="2022-09-20T19:41:07Z" title="Tuesday, September 20th 2022, 3:41:07 pm -04:00">Sep 20, 2022</time>_
---

Included `ccv precheck` target in `Makefile-build`.
Added the target in `CICD Makefile`.
Added ccv binary in the list of binaries downloaded during `make init`. 

Ran tests using `apimangeservice` branch `US40776_contract_input_validation`.

1. Running `make verify` on an "incorrect" contract results in error code 1 with execution being halted.
2. Running `make contract` executes `ccv precheck` on the contract in the service.