### PR TITLE
US41363 client cert opensearch

### DIFF
--- a/pkg/opensearch/client.go
+++ b/pkg/opensearch/client.go
@@ -2,6 +2,9 @@ package opensearch
 
 import (
 	"context"
+	"crypto/tls"
+	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/bootstrap"
+	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/tlsconfig"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/utils"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/utils/order"
 	"errors"
@@ -11,6 +14,7 @@ import (
 	"github.com/opensearch-project/opensearch-go/opensearchutil"
 	"go.uber.org/fx"
 	"io"
+	"net/http"
 	"reflect"
 )
 
@@ -83,15 +87,46 @@ func NewClient(di newClientDI) (OpenClient, error) {
 
 type configDI struct {
 	fx.In
-	Properties *Properties
+	Properties         *Properties
+	TlsProviderFactory *tlsconfig.ProviderFactory
 }
 
-func NewConfig(di configDI) opensearch.Config {
-	return opensearch.Config{
+func NewConfig(ctx *bootstrap.ApplicationContext, di configDI) (opensearch.Config, error) {
+	conf := opensearch.Config{
 		Addresses: di.Properties.Addresses,
 		Username:  di.Properties.Username,
 		Password:  di.Properties.Password,
 	}
+
+	if di.Properties.TLS.Enable {
+		p, err := di.TlsProviderFactory.GetProvider(di.Properties.TLS.Config)
+		if err != nil {
+			return conf, err
+		}
+		getClientCertificateFn, err := p.GetClientCertificate(ctx)
+		if err != nil {
+			return conf, err
+		}
+		caCertPool, err := p.RootCAs(ctx)
+		if err != nil {
+			return conf, err
+		}
+		minTLSVersion, err := p.GetMinTlsVersion()
+		if err != nil {
+			return conf, err
+		}
+		//nolint:gosec
+		tlsConf := &tls.Config{
+			GetClientCertificate: getClientCertificateFn,
+			RootCAs:              caCertPool,
+			MinVersion:           minTLSVersion,
+		}
+		conf.Transport = &http.Transport{
+			TLSClientConfig: tlsConf,
+		}
+	}
+
+	return conf, nil
 }
 
 type OpenClientImpl struct {
@@ -202,8 +237,9 @@ func (c *OpenClientImpl) RemoveAfterHook(hook AfterHook) {
 // BeforeContext is the context given to a BeforeHook
 //
 // Options will be in the form *[]func(request *Request){}, example:
-// 	options := make([]func(request *opensearchapi.SearchRequest), 0)
-// 	BeforeContext{Options: &options}
+//
+//	options := make([]func(request *opensearchapi.SearchRequest), 0)
+//	BeforeContext{Options: &options}
 type BeforeContext struct {
 	cmd     CommandType
 	Options interface{}
@@ -246,8 +282,9 @@ func (f BeforeHookFunc) Before(ctx context.Context, before BeforeContext) contex
 // AfterContext is the context given to a AfterHook
 //
 // Options will be in the form *[]func(request *Request){} example:
-// 	options := make([]func(request *opensearchapi.SearchRequest), 0)
-// 	AfterContext{Options: &options}
+//
+//	options := make([]func(request *opensearchapi.SearchRequest), 0)
+//	AfterContext{Options: &options}
 //
 // Resp and Err can be modified before they are returned out of Request of OpenClientImpl
 // example being OpenClientImpl.Search

--- a/pkg/opensearch/package.go
+++ b/pkg/opensearch/package.go
@@ -5,6 +5,7 @@ import (
 	appconfig "cto-github.cisco.com/NFV-BU/go-lanai/pkg/appconfig/init"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/bootstrap"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/log"
+	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/tlsconfig"
 	"go.uber.org/fx"
 )
 
@@ -23,6 +24,7 @@ var Module = &bootstrap.Module{
 
 func Use() {
 	bootstrap.Register(Module)
+	bootstrap.Register(tlsconfig.Module)
 }
 
 type regDI struct {

--- a/pkg/opensearch/ping.go
+++ b/pkg/opensearch/ping.go
@@ -21,7 +21,7 @@ func (c *RepoImpl[T]) Ping(
 }
 
 func (c *OpenClientImpl) Ping(ctx context.Context, o ...Option[opensearchapi.PingRequest]) (*opensearchapi.Response, error) {
-	options := make([]func(request *opensearchapi.PingRequest), 0, len(o))
+	options := make([]func(request *opensearchapi.PingRequest), len(o))
 	for i, v := range o {
 		options[i] = v
 	}

--- a/pkg/opensearch/properties.go
+++ b/pkg/opensearch/properties.go
@@ -2,6 +2,7 @@ package opensearch
 
 import (
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/bootstrap"
+	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/tlsconfig"
 	"embed"
 	"github.com/pkg/errors"
 )
@@ -17,15 +18,16 @@ type Properties struct {
 	Addresses []string `json:"addresses"`
 	Username  string   `json:"username"`
 	Password  string   `json:"password"`
-	CACert    string   `json:""`
+	TLS       TLS      `json:"TLS"`
+}
+
+type TLS struct {
+	Enable bool                 `json:"enable"`
+	Config tlsconfig.Properties `json:"config"`
 }
 
 func NewOpenSearchProperties() *Properties {
-	return &Properties{
-		Addresses: []string{"http://localhost:9200"},
-		Username:  "admin",
-		Password:  "admin",
-	}
+	return &Properties{} // None by default, they should all be defined in the defaults-opensearch.yml
 }
 
 func BindOpenSearchProperties(ctx *bootstrap.ApplicationContext) *Properties {

--- a/test/opensearchtest/opensearch_test.go
+++ b/test/opensearchtest/opensearch_test.go
@@ -2,6 +2,11 @@ package opensearchtest
 
 import (
 	"context"
+	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/tlsconfig"
+	"net/http"
+	"testing"
+	"time"
+
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/opensearch"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/tracing"
 	"cto-github.cisco.com/NFV-BU/go-lanai/pkg/tracing/instrument"
@@ -11,9 +16,6 @@ import (
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"go.uber.org/fx"
-	"net/http"
-	"testing"
-	"time"
 )
 
 //func TestMain(m *testing.M) {
@@ -53,7 +55,7 @@ func TestScopeController(t *testing.T) {
 			SetRecordDelay(time.Millisecond*1500),
 		),
 		apptest.WithTimeout(time.Minute),
-		apptest.WithModules(opensearch.Module),
+		apptest.WithModules(opensearch.Module, tlsconfig.Module),
 		apptest.WithFxOptions(
 			fx.Provide(NewFakeService),
 		),


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2022-10-21T18:27:09Z" title="Friday, October 21st 2022, 2:27:09 pm -04:00">Oct 21, 2022</time>_
_Merged <time datetime="2022-10-21T21:06:52Z" title="Friday, October 21st 2022, 5:06:52 pm -04:00">Oct 21, 2022</time>_
---

Enables go-lanai's opensearch client to connect to opensearch via basic auth, and via client certificates. 