### PR TITLE
added debug log for opensearch operations

### DIFF
--- a/pkg/opensearch/health.go
+++ b/pkg/opensearch/health.go
@@ -22,6 +22,7 @@ func NewHealthIndicator(client OpenClient) *HealthIndicator {
 func (i *HealthIndicator) Health(c context.Context, options health.Options) health.Health {
 	resp, err := i.client.Ping(c)
 	if err == nil && !resp.IsError() {
+		logger.WithContext(c).Debugf("error response: %s", resp.String())
 		return health.NewDetailedHealth(health.StatusUp, "opensearch ping succeeded", nil)
 	}
 	return health.NewDetailedHealth(health.StatusDown, "opensearch ping failed", nil)

--- a/pkg/opensearch/index.go
+++ b/pkg/opensearch/index.go
@@ -20,6 +20,7 @@ func (c *RepoImpl[T]) Index(ctx context.Context, index string, document T, o ...
 		return err
 	}
 	if resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/indicescreate.go
+++ b/pkg/opensearch/indicescreate.go
@@ -25,6 +25,7 @@ func (c *RepoImpl[T]) IndicesCreate(
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/indicesdelete.go
+++ b/pkg/opensearch/indicesdelete.go
@@ -12,6 +12,7 @@ func (c *RepoImpl[T]) IndicesDelete(ctx context.Context, index []string, o ...Op
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/indicesdeletealias.go
+++ b/pkg/opensearch/indicesdeletealias.go
@@ -12,6 +12,7 @@ func (c *RepoImpl[T]) IndicesDeleteAlias(ctx context.Context, index []string, na
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/indicesdeleteindextemplate.go
+++ b/pkg/opensearch/indicesdeleteindextemplate.go
@@ -12,6 +12,7 @@ func (c *RepoImpl[T]) IndicesDeleteIndexTemplate(ctx context.Context, name strin
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/indicesget.go
+++ b/pkg/opensearch/indicesget.go
@@ -35,6 +35,7 @@ func (c *RepoImpl[T]) IndicesGet(ctx context.Context, index string, o ...Option[
 		return nil, err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return nil, fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 

--- a/pkg/opensearch/indicesputalias.go
+++ b/pkg/opensearch/indicesputalias.go
@@ -16,6 +16,7 @@ func (c *RepoImpl[T]) IndicesPutAlias(ctx context.Context,
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/indicesputindextemplate.go
+++ b/pkg/opensearch/indicesputindextemplate.go
@@ -20,6 +20,7 @@ func (c *RepoImpl[T]) IndicesPutIndexTemplate(ctx context.Context, name string, 
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/ping.go
+++ b/pkg/opensearch/ping.go
@@ -15,6 +15,7 @@ func (c *RepoImpl[T]) Ping(
 		return err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/opensearch/search.go
+++ b/pkg/opensearch/search.go
@@ -46,6 +46,7 @@ func (c *RepoImpl[T]) Search(ctx context.Context, dest *[]T, body interface{}, o
 		return 0, err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return 0, fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	respBody, err := io.ReadAll(resp.Body)

--- a/pkg/opensearch/searchtemplate.go
+++ b/pkg/opensearch/searchtemplate.go
@@ -21,6 +21,7 @@ func (c *RepoImpl[T]) SearchTemplate(ctx context.Context, dest *[]T, body interf
 		return 0, err
 	}
 	if resp != nil && resp.IsError() {
+		logger.WithContext(ctx).Debugf("error response: %s", resp.String())
 		return 0, fmt.Errorf("error status code: %d", resp.StatusCode)
 	}
 	respBody, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2022-11-07T22:14:32Z" title="Monday, November 7th 2022, 5:14:32 pm -05:00">Nov 7, 2022</time>_
_Merged <time datetime="2022-11-07T23:16:28Z" title="Monday, November 7th 2022, 6:16:28 pm -05:00">Nov 7, 2022</time>_
---

Added debug log to print the response from opensearch server when the server returns error. This way we can see the error details.

The debug log can be enabled by setting ```log.levels.Search=debug```