### PR TITLE
Add error logging to the opensearch health check

### DIFF
--- a/pkg/opensearch/health.go
+++ b/pkg/opensearch/health.go
@@ -21,8 +21,13 @@ func NewHealthIndicator(client OpenClient) *HealthIndicator {
 
 func (i *HealthIndicator) Health(c context.Context, options health.Options) health.Health {
 	resp, err := i.client.Ping(c)
-	if err == nil && !resp.IsError() {
-		return health.NewDetailedHealth(health.StatusUp, "opensearch ping succeeded", nil)
+	if err != nil {
+		logger.WithContext(c).Errorf("unable to ping opensearch: %v", err)
+		return health.NewDetailedHealth(health.StatusDown, "opensearch ping failed", nil)
 	}
-	return health.NewDetailedHealth(health.StatusDown, "opensearch ping failed", nil)
+	if resp.IsError() {
+		logger.WithContext(c).Errorf("unable to ping opensearch: %v", resp.String())
+		return health.NewDetailedHealth(health.StatusDown, "opensearch ping failed", nil)
+	}
+	return health.NewDetailedHealth(health.StatusUp, "opensearch ping succeeded", nil)
 }


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2022-11-22T17:27:08Z" title="Tuesday, November 22nd 2022, 12:27:08 pm -05:00">Nov 22, 2022</time>_
_Merged <time datetime="2022-11-22T17:52:26Z" title="Tuesday, November 22nd 2022, 12:52:26 pm -05:00">Nov 22, 2022</time>_
---

Adds some basic health check error logging