### PR TITLE
PLAT-2006 Give opensearchtest EditIndexForTestHook high priority

### DIFF
--- a/test/opensearchtest/package.go
+++ b/test/opensearchtest/package.go
@@ -16,6 +16,10 @@ import (
 	"time"
 )
 
+// IndexSuffix is the suffix we append to the index name when running opensearch tests, so that we don't
+// corrupt the application's indices.
+const IndexSuffix = "_test"
+
 // IsRecording returns true if copyist is currently in recording mode.
 // We wrap the copyist.IsRecording because we re-use the same commandline flag
 // as the copyist library, and flag.Bool doesn't like it when you have two places
@@ -187,7 +191,7 @@ func (e *EditIndexForTestingHook) Order() int {
 
 func NewEditingIndexForTestingHook() opensearch.BeforeHook {
 	return &EditIndexForTestingHook{
-		Suffix: "_test",
+		Suffix: IndexSuffix,
 	}
 }
 


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2022-12-12T15:36:56Z" title="Monday, December 12th 2022, 10:36:56 am -05:00">Dec 12, 2022</time>_
_Merged <time datetime="2022-12-13T21:10:08Z" title="Tuesday, December 13th 2022, 4:10:08 pm -05:00">Dec 13, 2022</time>_
---

Make this hook a high priority hook, because we may have other hook in service that manipulates the index name further.

See https://cto-github.cisco.com/NFV-BU/auditingservice/pull/35 for details.