### PR TITLE
updated crewsaml version to get its patch for a vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.0.1
 	github.com/cockroachdb/copyist v1.4.1
 	github.com/crewjam/httperr v0.2.0
-	github.com/crewjam/saml v0.4.8
+	github.com/crewjam/saml v0.4.9
 	github.com/getkin/kin-openapi v0.103.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gin-gonic/gin v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.8 h1:XPrpg7DOIqh7AvMXPMRzHylzzb/ltgnfRRilwCgYb5A=
 github.com/crewjam/saml v0.4.8/go.mod h1:9Zh6dWPtB3MSzTRt8fIFH60Z351QQ+s7hCU3J/tTlA4=
+github.com/crewjam/saml v0.4.9 h1:X2jDv4dv3IvfT9t+RhADavzNFAcq3fVxzTCIH3G605U=
+github.com/crewjam/saml v0.4.9/go.mod h1:9Zh6dWPtB3MSzTRt8fIFH60Z351QQ+s7hCU3J/tTlA4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
> [<img alt="tishi" height="40" width="40" align="left" src="https://avatars.githubusercontent.com/u/742440?v=4">](/TimShi) **Authored by [TimShi](/TimShi)**
_<time datetime="2022-12-12T16:01:10Z" title="Monday, December 12th 2022, 11:01:10 am -05:00">Dec 12, 2022</time>_
_Merged <time datetime="2022-12-13T18:10:21Z" title="Tuesday, December 13th 2022, 1:10:21 pm -05:00">Dec 13, 2022</time>_
---

Update crewsaml from 0.4.8 to 0.4.9 to get this vulnerability fix. https://github.com/advisories/GHSA-j2jp-wvqg-wc2g

This is the only change between 0.4.8 and 0.4.9 https://github.com/crewjam/saml/compare/v0.4.8...v0.4.9