### PR TITLE
Add Golden File Utility to Go-Lanai

### DIFF
--- a/test/golden/golden_test.go
+++ b/test/golden/golden_test.go
@@ -75,3 +75,71 @@ func SubTestWithTableDriven() test.GomegaSubTestFunc {
 		}
 	}
 }
+
+type MockTestingT struct {
+	*testing.T
+	FatalfCalled bool
+}
+
+const (
+	MockFatalPanic = "Mock Fatal Panic"
+)
+
+// Fatalf will not actually fatal the test, but will panic to exit the execution
+func (c *MockTestingT) Fatalf(format string, args ...any) {
+	c.FatalfCalled = true
+	panic(MockFatalPanic)
+}
+func TestAssert(t *testing.T) {
+	type args struct {
+		t    *testing.T
+		data interface{}
+	}
+	tests := []struct {
+		name              string
+		args              args
+		expectFatalCalled bool
+	}{
+		{
+			name: "Test Struct Data, expects no error",
+			args: args{
+				t: t,
+				data: struct {
+					Hello string
+				}{
+					Hello: "some string",
+				},
+			},
+		},
+		{
+			name: "Test nil Data, expects fatal error",
+			args: args{
+				t:    t,
+				data: nil,
+			},
+			expectFatalCalled: true,
+		},
+		{
+			name: "Test Non Struct Data, expects fatal error",
+			args: args{
+				t:    t,
+				data: []byte("hello"),
+			},
+			expectFatalCalled: true,
+		},
+	}
+	for _, tt := range tests {
+		mT := MockTestingT{t, false}
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != MockFatalPanic {
+					t.Errorf("only expected %v, did not expect :%v panic", MockFatalPanic, r)
+				}
+				if tt.expectFatalCalled && mT.FatalfCalled != true {
+					t.Errorf("expected fatal error but did not receive fatal error")
+				}
+			}()
+			Assert(&mT, tt.args.data)
+		})
+	}
+}


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2023-01-04T21:10:02Z" title="Wednesday, January 4th 2023, 4:10:02 pm -05:00">Jan 4, 2023</time>_
_Merged <time datetime="2023-01-10T06:45:26Z" title="Tuesday, January 10th 2023, 1:45:26 am -05:00">Jan 10, 2023</time>_
---

The utility provides functionality to automatically grab the Test Name,
and the SubTests names. Given a struct, you can use it to save/overwrite
golden files using the `WriteGoldenFiles` function, or Assert that the
data is equal to whatever is currently saved using the `Assert`
function.

An example of a diff

The expected ownerTenantId: `helloTenantId123456`, and what our function returned `ownerTenantId12345`  
![image](https://cto-github.cisco.com/storage/user/9226/files/bfabdd4e-a075-4e50-9722-c43370b217aa)

For the files, the utility automatically writes to these file locations when using the `WriteGoldenFiles`. It also will read from these locations for the `Assert`
![image](https://cto-github.cisco.com/storage/user/9226/files/922952f0-70e3-41f3-a757-37c42be3822e)

Running the function in a test
![image](https://cto-github.cisco.com/storage/user/9226/files/225c9724-9fb3-4174-9ab0-0b5409ddb26b)

