### PR TITLE
Moves the tenant caching to the tenancy internalAccessor

### DIFF
--- a/pkg/tenancy/context.go
+++ b/pkg/tenancy/context.go
@@ -17,8 +17,6 @@ const STATUS_IN_PROGRESS = "IN_PROGRESS"
 const STATUS_LOADED = "LOADED"
 const STATUS_FAILED_TO_LOAD_ROOT_TENANT = "FAILED_TO_LOAD_ROOT_TENANT"
 
-var cachedRootId string
-
 type Accessor interface {
 	GetParent(ctx context.Context, tenantId string) (string, error)
 	GetChildren(ctx context.Context, tenantId string) ([]string, error)
@@ -55,12 +53,7 @@ func GetDescendants(ctx context.Context, tenantId string) ([]string, error) {
 GetRoot because root tenantId won't change once system is started, we can cache it after first successful read.
 */
 func GetRoot(ctx context.Context) (string, error) {
-	if cachedRootId != "" {
-		return cachedRootId, nil
-	}
-	var err error
-	cachedRootId, err = internalAccessor.GetRoot(ctx)
-	return cachedRootId, err
+	return internalAccessor.GetRoot(ctx)
 }
 
 func GetTenancyPath(ctx context.Context, tenantId string) ([]uuid.UUID, error) {


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2023-02-14T23:26:31Z" title="Tuesday, February 14th 2023, 6:26:31 pm -05:00">Feb 14, 2023</time>_
_Merged <time datetime="2023-02-14T23:52:21Z" title="Tuesday, February 14th 2023, 6:52:21 pm -05:00">Feb 14, 2023</time>_
---

null