### PR TITLE
WithNonEmptyURLValues will ignore empty strings

### DIFF
--- a/pkg/integrate/security/seclient/client.go
+++ b/pkg/integrate/security/seclient/client.go
@@ -233,11 +233,17 @@ func (c *remoteAuthClient) withClientAuth(opt *AuthOption) httpclient.RequestOpt
 // WithNonEmptyURLValues will accept a map[key][values] and convert it to a url.Values.
 // The function will check that the values, typed []string has a length > 0. Otherwise,
 // will not insert the key into the url.Values
-func WithNonEmptyURLValues(values map[string][]string) url.Values {
+func WithNonEmptyURLValues(mappedValues map[string][]string) url.Values {
 	urlValues := url.Values{}
-	for valueKey, value := range values {
-		if len(value) > 0 {
-			urlValues[valueKey] = value
+	for valueKey, values := range mappedValues {
+		var nonEmptyValues []string
+		for _, value := range values {
+			if value != "" {
+				nonEmptyValues = append(nonEmptyValues, value)
+			}
+		}
+		if len(nonEmptyValues) > 0 {
+			urlValues[valueKey] = nonEmptyValues
 		}
 	}
 	return urlValues

--- a/pkg/integrate/security/seclient/client_test.go
+++ b/pkg/integrate/security/seclient/client_test.go
@@ -138,6 +138,16 @@ func TestWithNonEmptyURLValues(t *testing.T) {
 				"key2": {"value1", "value2"},
 			},
 		},
+		{
+			name: "two keys, first has empty values, but using urlValues",
+			args: args{values: url.Values{
+				"key1": {""},
+				"key2": {"value1", "value2"},
+			}},
+			want: url.Values{
+				"key2": {"value1", "value2"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2023-04-18T16:36:37Z" title="Tuesday, April 18th 2023, 12:36:37 pm -04:00">Apr 18, 2023</time>_
_Merged <time datetime="2023-04-18T17:52:40Z" title="Tuesday, April 18th 2023, 1:52:40 pm -04:00">Apr 18, 2023</time>_
---

Bug caused by adding `Scope` to all the existing remoteAuthClient functions:
https://cto-github.cisco.com/NFV-BU/go-lanai/pull/301/files#diff-b034d20abcd5c7ff31be34b1b7f2d373096f8fb6d07fbaf4964b900e85ff0f6cR112

Did not handle the case where the scope might have an empty string. If we receive an empty string and only an empty string in the scopes config, then I think we need to avoid putting `Scope` in the url.Values