### PR TITLE
removes r.Body=http.NoBody with nil, Seems like cci does not like NoBody

### DIFF
--- a/pkg/integrate/httpclient/request.go
+++ b/pkg/integrate/httpclient/request.go
@@ -42,7 +42,7 @@ func NewRequest(path, method string, opts ...RequestOptions) *Request {
 
 func EncodeJSONRequest(c context.Context, r *http.Request, request interface{}) error {
 	if request == nil {
-		r.Body = http.NoBody
+		r.Body = nil
 		r.GetBody = nil
 		r.ContentLength = 0
 		return nil


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2023-06-09T16:35:36Z" title="Friday, June 9th 2023, 12:35:36 pm -04:00">Jun 9, 2023</time>_
_Merged <time datetime="2023-06-09T17:15:21Z" title="Friday, June 9th 2023, 1:15:21 pm -04:00">Jun 9, 2023</time>_
---

Snippet from http/request.go::NewRequestWithContext
![image](https://cto-github.cisco.com/storage/user/9226/files/842fc31d-ec5b-4d42-9280-b40a21f56d99)

I had initially tested my fix with:
```go
	if request == nil {
		return nil
	}
```
However, after checking with http/request.go, it looked like adding `NoBody` was the correct thing to do. After re-running the test, I can see that was a mistake. 

I think it slipped through because I had originally tested my fix with a manual test that went around the workaround we had in [bifrost-portal-service](https://cto-github.cisco.com/NFV-BU/bifrost-portal-service/pull/96/files#diff-7feed95bd19f39083fcfb2b35c3a534bc8dae9101ee222250364557d8b531907L153) 

I'm not sure how the above PR was re-recorded w/o issues though once I took out the workaround... Maybe the NoBody didn't affect the test and I didn't have to re-record? I'm not sure. 


