### PR TITLE
Add verify-contract target to Makefile-Build.

### DIFF
--- a/cmd/lanai-cli/initcmd/Makefile-Build.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile-Build.tmpl
@@ -100,3 +100,8 @@ resource@{{ .Output }}:
 # Runs contract-verifier precheck to verify service contract against CPX guidelines
 contract:
 	ccv precheck
+
+# Runs contract-verify to check if implementation matches the contract
+# precheck disabled as we expect pipeline to perform that separately via preceding target
+verify-contract:
+	ccv check  --enable-precheck=false


### PR DESCRIPTION
> [<img alt="scolehma" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/scolehma) **Authored by [scolehma](https://cto-github.cisco.com/scolehma)**
_<time datetime="2023-06-12T17:04:32Z" title="Monday, June 12th 2023, 1:04:32 pm -04:00">Jun 12, 2023</time>_
_Merged <time datetime="2023-06-12T19:17:35Z" title="Monday, June 12th 2023, 3:17:35 pm -04:00">Jun 12, 2023</time>_
---

A `verify-contract` target existed in some projects via manual edits (with inconsistent behahvior), but since the pipeline is invoking it, we should make the target "official" and promote consistency across services.

This is based on what is in the `Makefile-Build` for `apimanageservice` currently, BUT explicitly disables the precheck - the pipeline is doing the precheck as a separate step already, and some builds are running the precheck twice right now (and the build shouldn't depend on the setting in the config file)  

Tested makefile generation with Manage (which doesn't pass `ccv check` yet, but it did run as expected).