### PR TITLE
CDAPLAT-132: Contract path appears to be relative to current directory

### DIFF
--- a/cmd/lanai-cli/codegen/README.md
+++ b/cmd/lanai-cli/codegen/README.md
@@ -115,7 +115,6 @@ Notes: If contract/templateDirectory are relative paths, they must be relative t
 contract: ./contract.yml
 repositoryRootPath: cto-github.cisco.com/NFV-BU/testservice
 projectName: testservice
-#templateDirectory:
 ```
 
 3. Run `lanai-cli codegen -o ./` Files will be generated to your directory:


### PR DESCRIPTION
> [<img alt="rihou" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/rihou) **Authored by [rihou](https://cto-github.cisco.com/rihou)**
_<time datetime="2023-06-12T20:51:00Z" title="Monday, June 12th 2023, 4:51:00 pm -04:00">Jun 12, 2023</time>_
_Merged <time datetime="2023-06-13T21:37:20Z" title="Tuesday, June 13th 2023, 5:37:20 pm -04:00">Jun 13, 2023</time>_
---

The change: 
 For the `contract` and `templateDirectory` properties in codegen config file, if they are relative paths, it is assumed that they are relative to the location of the codegen config file. 