### PR TITLE
Update migrate exec config in example Module.yml

### DIFF
--- a/docs/res/Example-Module.yml
+++ b/docs/res/Example-Module.yml
@@ -6,6 +6,7 @@ execs:
     port: 8080
   migrate:
     main: cmd/europa/migrate.go
+    type: migrator
   seeder:
     main: cmd/europa/seeder.go
 


### PR DESCRIPTION
> [<img alt="scolehma" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/scolehma) **Authored by [scolehma](https://cto-github.cisco.com/scolehma)**
_<time datetime="2023-07-05T22:54:35Z" title="Wednesday, July 5th 2023, 6:54:35 pm -04:00">Jul 5, 2023</time>_
_Merged <time datetime="2023-07-06T15:16:36Z" title="Thursday, July 6th 2023, 11:16:36 am -04:00">Jul 6, 2023</time>_
---

Using the example `Module.yml` in the docs resulted in a microservice that did not support the migrations during deployment.  Turns out that some additional config of `type: migrator` is necessary to have the necessary logic generated in dockerlaunch.sh:
https://cto-github.cisco.com/NFV-BU/go-lanai/blob/4fef379e64f9569815b64f732146f95c3bb0744a/cmd/lanai-cli/initcmd/dockerlaunch.tmpl#L9-L14

This PR just updates the example with the added key, though I expect that `Module.yml` will end up being generated since it has some values that need to match other generated code.