### PR TITLE
Fix the test by calling the subtest

### DIFF
--- a/pkg/security/config/integration_test.go
+++ b/pkg/security/config/integration_test.go
@@ -417,7 +417,7 @@ func SubTestOauth2SwitchTenantWithPerTenantPermission(di *intDI) test.GomegaSubT
 				),
 			},
 		}
-		SubTestOauth2SwitchTenant(di, tests, fedAccount)
+		SubTestOauth2SwitchTenant(di, tests, fedAccount)(ctx, t, g)
 	}
 }
 
@@ -453,7 +453,7 @@ func SubTestOAuth2SwitchTenantNoFinalizer(di *intDI) test.GomegaSubTestFunc {
 				),
 			},
 		}
-		SubTestOauth2SwitchTenant(di, tests, fedAccount)
+		SubTestOauth2SwitchTenant(di, tests, fedAccount)(ctx, t, g)
 	}
 }
 


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2023-08-18T06:22:14Z" title="Friday, August 18th 2023, 2:22:14 am -04:00">Aug 18, 2023</time>_
_Merged <time datetime="2023-08-23T15:59:25Z" title="Wednesday, August 23rd 2023, 11:59:25 am -04:00">Aug 23, 2023</time>_
---

Previously had the test factored out so it could be used in different
tests. The code was extracted into its own function, but the returned
gomega SubTestFunc was not executed.