### PR TITLE
Finalizer will accept a nil tenant

### DIFF
--- a/pkg/security/account.go
+++ b/pkg/security/account.go
@@ -69,7 +69,7 @@ type Account interface {
 }
 
 type AccountFinalizeOption struct {
-	Tenant *Tenant
+	Tenant *Tenant // Tenant field can be nil
 }
 type AccountFinalizeOptions func(option *AccountFinalizeOption)
 

--- a/pkg/security/oauth2/auth/service.go
+++ b/pkg/security/oauth2/auth/service.go
@@ -289,7 +289,7 @@ func (s *DefaultAuthorizationService) loadAndVerifyFacts(ctx context.Context, re
 		return nil, err
 	}
 
-	if finalizer, ok := s.accountStore.(security.AccountFinalizer); ok && tenant != nil {
+	if finalizer, ok := s.accountStore.(security.AccountFinalizer); ok {
 		newAccount, err := finalizer.Finalize(ctx, account, security.FinalizeWithTenant(tenant))
 		if err != nil {
 			return nil, err

--- a/test/sectest/mocks_account_store.go
+++ b/test/sectest/mocks_account_store.go
@@ -31,13 +31,14 @@ func (m *MockAccountStoreWithFinalize) Finalize(
 	for _, option := range options {
 		option(&opts)
 	}
-	if opts.Tenant == nil {
-		return nil, fmt.Errorf("expected non nil tenant")
-	}
 
 	u, ok := m.accountLookupByUsername[account.Username()]
 	if !ok {
 		return nil, fmt.Errorf("username: %v not found", account.Username())
+	}
+	if opts.Tenant == nil {
+		u.MockedAccountDetails.Permissions = utils.NewStringSet(security.SpecialPermissionSwitchTenant)
+		return u, nil
 	}
 	tenant, ok := m.tenantIDLookup[opts.Tenant.Id]
 	if !ok {


### PR DESCRIPTION
> [<img alt="bseto" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/bseto) **Authored by [bseto](https://cto-github.cisco.com/bseto)**
_<time datetime="2023-08-25T06:51:21Z" title="Friday, August 25th 2023, 2:51:21 am -04:00">Aug 25, 2023</time>_
_Merged <time datetime="2023-08-31T07:04:20Z" title="Thursday, August 31st 2023, 3:04:20 am -04:00">Aug 31, 2023</time>_
---

We need the finalizer to accept a nil tenant. The finalizer can decide what to do if the tenant is nil.

In my case, I need to know if it's nil so I can provide default permissions such as `SWITCH_TENANT` 