### PR TITLE
Adding has_any_permission in rbac bundle 

### DIFF
--- a/pkg/opa/test/bundle/rbac/hasanypermission.rego
+++ b/pkg/opa/test/bundle/rbac/hasanypermission.rego
@@ -1,0 +1,25 @@
+# +short current user has any given permission
+# +desc Checks if current user has given string array of permissions
+package rbac
+
+import future.keywords
+import data.oauth2.jwt_claims
+
+# +desc Check permissions with Auth from input
+# +entrypoint
+has_any_permission(p) {
+    has_auth
+    # iterate through both list and set and return intersection
+    result := {x | x = input.auth.permissions[_]; x = p[_]}
+    count(result) > 0
+}
+
+
+# +desc check permissions with JWT
+has_any_permission(p) {
+    not has_auth
+    some role in jwt_claims.roles
+    # iterate through both list and set and return intersection
+    result := {x | x = data.role_permissions[role][_]; x = p[_]}
+    count(result) > 0
+}


### PR DESCRIPTION
> [<img alt="siskande" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/siskande) **Authored by [siskande](https://cto-github.cisco.com/siskande)**
_<time datetime="2023-09-06T14:43:03Z" title="Wednesday, September 6th 2023, 10:43:03 am -04:00">Sep 6, 2023</time>_
_Merged <time datetime="2023-09-06T16:15:57Z" title="Wednesday, September 6th 2023, 12:15:57 pm -04:00">Sep 6, 2023</time>_
---

Adds new constraint that takes in any number of permissions for access control.

The file was copied and pasted from cda-policy-service and cda-auth-service.

Related PR's:
https://cto-github.cisco.com/NFV-BU/cda-policy-service/pull/4
https://cto-github.cisco.com/NFV-BU/cda-auth-service/pull/35