### PR TITLE
Log some errors processing swagger requests.

### DIFF
--- a/pkg/swagger/controllers.go
+++ b/pkg/swagger/controllers.go
@@ -168,6 +168,7 @@ func (c *SwaggerController) oas2Doc(w http.ResponseWriter, r *http.Request) {
 	var err error
 	defer func() {
 		if err != nil {
+			logger.WithContext(r.Context()).Errorf("Failed to serve OAS document: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}()
@@ -194,6 +195,7 @@ func (c *SwaggerController) oas3Doc(w http.ResponseWriter, r *http.Request) {
 	var err error
 	defer func() {
 		if err != nil {
+			logger.WithContext(r.Context()).Errorf("Failed to serve OAS document: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}()
@@ -217,13 +219,16 @@ func (c *SwaggerController) oas3Doc(w http.ResponseWriter, r *http.Request) {
 
 func (c *SwaggerController) swaggerRedirect(w http.ResponseWriter, r *http.Request) {
 	fs := http.FS(Content)
-	file, err := fs.Open("generated/swagger-sso-redirect.html")
+	path := "generated/swagger-sso-redirect.html"
+	file, err := fs.Open(path)
 	if err != nil {
+		logger.WithContext(r.Context()).Errorf("Unable to open file '%s': %v", path, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	fileInfo, err := file.Stat()
 	if err != nil {
+		logger.WithContext(r.Context()).Errorf("Unable to stat file '%s': %v", path, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
> [<img alt="scolehma" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/scolehma) **Authored by [scolehma](https://cto-github.cisco.com/scolehma)**
_<time datetime="2023-10-05T15:49:59Z" title="Thursday, October 5th 2023, 11:49:59 am -04:00">Oct 5, 2023</time>_
_Merged <time datetime="2023-10-06T00:45:14Z" title="Thursday, October 5th 2023, 8:45:14 pm -04:00">Oct 5, 2023</time>_
---

Add logging of some errors when processing swagger related requests.

With the problem energy manager contract, it will now log something like:
```
2023-10-05T15:52:01.906Z  ERROR [  controllers.go:199]      Swagger: Failed to serve OAS document: error converting YAML to JSON: yaml: line 182: found unknown escape character {traceId="58bf875772c191f3", spanId="58bf875772c191f3"}

```