### PR TITLE
CDAPLAT-1003 Adding actuator bundle to opa/test

### DIFF
--- a/pkg/opa/test/bundle/actuator/endpoint.rego
+++ b/pkg/opa/test/bundle/actuator/endpoint.rego
@@ -1,0 +1,25 @@
+# +short        client is authorized to access actuator endpoint
+# +desc         Example of checking if client is allowed to access API based on scopes
+package actuator
+
+import data.oauth2.has_scope
+
+# +desc alive is public
+allow_endpoint {
+    input.request.endpoint_id = "alive"
+}
+
+# +desc health is public
+allow_endpoint {
+    input.request.endpoint_id = "health"
+}
+
+# +desc info is public
+allow_endpoint {
+    input.request.endpoint_id = "info"
+}
+
+# +desc the rest endpoints are protected by scope
+allow_endpoint {
+    has_scope("admin")
+}

--- a/pkg/opa/test/bundle/actuator/health.rego
+++ b/pkg/opa/test/bundle/actuator/health.rego
@@ -1,0 +1,10 @@
+# +short        client is authorized to access health details
+# +desc         Example of checking if client is allowed to access health details
+package actuator
+
+import data.oauth2.has_scope
+
+# +desc client with
+allow_health_details {
+    has_scope("admin")
+}


### PR DESCRIPTION
> [<img alt="siskande" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://cto-github.cisco.com/siskande) **Authored by [siskande](https://cto-github.cisco.com/siskande)**
_<time datetime="2023-11-15T21:14:02Z" title="Wednesday, November 15th 2023, 4:14:02 pm -05:00">Nov 15, 2023</time>_
_Merged <time datetime="2023-11-15T22:30:59Z" title="Wednesday, November 15th 2023, 5:30:59 pm -05:00">Nov 15, 2023</time>_
---

For our cda-auth-service tests, we reference our constraint bundles from this location. It was missing the actuator bundle.

Bundle files were copied directly from cda-policy-service.