### PR TITLE
Update GitHub team permission settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -31,8 +31,14 @@ teams:
     # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
     permission: admin
 
-  - name: go-lanai
+  - name: go-lanai-admins
     permission: admin
+
+  - name: go-lanai-maintainers
+    permission: maintain
+
+  - name: go-lanai
+    permission: triage
 
 # Collaborators: give specific users access to this repository.
 # See https://docs.github.com/en/rest/reference/collaborators for available options


### PR DESCRIPTION
## Description

Updates `settings.yml` to configure the new GitHub team structure:

Parent team: [go-lanai](https://github.com/orgs/cisco-open/teams/go-lanai)
- Child team: [go-lanai-admins](https://github.com/orgs/cisco-open/teams/go-lanai-admins)
- Child team: [go-lanai-maintainers](https://github.com/orgs/cisco-open/teams/go-lanai-maintainers)

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)