### PR TITLE
Updated Dockerfile and Makefile templates to properly initialize l environment

### DIFF
--- a/cmd/lanai-cli/initcmd/Dockerfile.tmpl
+++ b/cmd/lanai-cli/initcmd/Dockerfile.tmpl
@@ -25,8 +25,8 @@ RUN if [ ! -z "$GITKEY" -a -e $GITKEY ]; then \
     fi
 
 RUN --mount=type=ssh \
-    make init-once init && \
-    make drop-replace && go mod tidy && \
+    make init-once init PRIVATE_MODS="$PRIVATE_MODS" && \
+    make drop-replace PRIVATE_MODS="$PRIVATE_MODS" && go mod tidy && \
     make clean build PRIVATE_MODS="$PRIVATE_MODS" VERSION="$VERSION";
 
 FROM ${BASE_IMAGE}

--- a/cmd/lanai-cli/initcmd/Makefile-CICD.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile-CICD.tmpl
@@ -12,7 +12,7 @@
 ## Variables from make command-line
 # PRIVATE_MODS:	private modules and its version/branch/tag to use. comma delimited if multiple modules
 # 				e.g. PRIVATE_MODS=github.com/<org>/<my-private-dependency>@v0.1.0,github.my-domain.com/<org>/<repo>@0.2.1
-PRIVATE_MODS ?= {{.CliModPath}}@develop
+PRIVATE_MODS ?=
 # VERSION:	application version to be distributed/build (without leading "v").
 # 			e.g. VERSION=4.0.0-50
 VERSION ?= 0.0.0-SNAPSHOT
@@ -131,7 +131,7 @@ build-docker: init-docker
 #		- DOCKER_TAG: default to $(VERSION)
 #		- DOCKER_REPO: Docker repository path/url without tailing "/"
 push-docker: DOCKER_TAG ?= $(VERSION)
-push-docker: DOCKER_REPO ?= dockerhub.cisco.com/vms-platform-dev-docker
+push-docker: DOCKER_REPO ?= registry-1.docker.io
 push-docker:
 	$(DOCKER) tag {{.Name}}:$(DOCKER_TAG) $(DOCKER_REPO)/{{.Name}}:$(DOCKER_TAG)
 	$(DOCKER) push $(DOCKER_REPO)/{{.Name}}:$(DOCKER_TAG)

--- a/cmd/lanai-cli/initcmd/Makefile.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile.tmpl
@@ -38,19 +38,17 @@ CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MO
 
 # init-once:
 #	Used to setup local dev environment, and should be used only once per environment.
-# 	This target assumes local environment has proper access to $PRIVATE_REPOS
-#	Required Vars:
-#		- PRIVATE_REPOS space delimited private git servers. e.g. PRIVATE_REPOS="private-github.my-domain.org"
-ifneq ($(strip $(value PRIVATE_REPOS)),)
+# 	This target assumes local environment has proper SSH access to $PRIVATE_MODS
+#	Optional Vars:
+#		- PRIVATE_MODS:	private modules and its version/branch/tag to use. comma delimited if multiple modules.
+# 		  e.g. PRIVATE_MODS="github.com/<org>/<my-private-dependency>@v0.1.0,github.my-domain.com/<org>/<repo>@0.2.1"
+init-once: PRIVATE_REPOS := $(foreach mod,$(subst $(comma),$(space),$(PRIVATE_MODS)),$(firstword $(subst @, ,$(mod))))
+init-once: GOPRIVATE := $(sort $(PRIVATE_REPOS) $(subst $(comma),$(space),$(shell $(GO) env GOPRIVATE)))
 init-once:
-	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(value PRIVATE_REPOS)))"
 	$(foreach repo,$(PRIVATE_REPOS),\
-		$(GIT) config --global url."ssh://git@$(repo)/".insteadOf "https://$(repo)/";\
+		$(GIT) config --global url."ssh://git@$(repo)".insteadOf "https://$(repo)"; \
 	)
-else
-init-once:
-	@echo "Nothing to be done. Did you forget to set PRIVATE_REPOS?"
-endif
+	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(GOPRIVATE)))"
 
 # init-ws:
 # 	create tmp folders
@@ -66,11 +64,11 @@ init-ws:
 #		- CLI_MOD_PATH the path of the go-lanai module on local file system. If provided, it would override CLI_TAG
 #		  e.g. CLI_MOD_PATH=./../go-lanai
 #		- CLI_TAG branch/tag to use to install "lanai-cli", typically same branch/tag of github.com/cisco-open/go-lanai
-#		  e.g. CLI_TAG=develop
+#		  e.g. CLI_TAG=main
 ifneq ("$(wildcard $(CLI_MOD_PATH)/go.mod)","")
 # For Contributors or Service Dev who have go-lanai checked out (either by-side or as parent) and have proper "replace" directive in go.mod
 init-cli: CLI_PKG = cmd/lanai-cli
-init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/cmd/lanai-cli
+init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/$(CLI_PKG)
 init-cli: CLI_VERSION = 0.0.0-$(shell cd $(CLI_MOD_PATH); date +"%Y%m%d%H%M%S")-$(shell $(GIT) rev-parse --short=12 HEAD || echo "SNAPSHOT")
 init-cli: print
 	@echo Installing $(CLI_MOD_PATH)/$(CLI_PKG)@$(CLI_VERSION) ...

--- a/examples/auth/Makefile
+++ b/examples/auth/Makefile
@@ -24,6 +24,7 @@ CLI_TAG ?=
 FORCE ?=
 UPGRADE ?=
 DEV ?=
+PRIVATE_MODS ?=
 
 ## Required Variables by Local Targets
 GO ?= go
@@ -38,19 +39,18 @@ CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MO
 
 # init-once:
 #	Used to setup local dev environment, and should be used only once per environment.
-# 	This target assumes local environment has proper access to $PRIVATE_REPOS
+# 	This target assumes local environment has proper SSH access to $PRIVATE_MODS
 #	Required Vars:
-#		- PRIVATE_REPOS space delimited private git servers. e.g. PRIVATE_REPOS="private-github.my-domain.org"
-ifneq ($(strip $(value PRIVATE_REPOS)),)
+#		- PRIVATE_MODS space delimited private golang modules.
+# 		  e.g. PRIVATE_REPOS="github.com/<org>/<private-repo>"
+#			   PRIVATE_REPOS="private-github.my-domain.org/path/to/module/repo"
+init-once: PRIVATE_REPOS := $(foreach mod,$(subst $(comma),$(space),$(PRIVATE_MODS)),$(firstword $(subst @, ,$(mod))))
+init-once: GOPRIVATE := $(sort $(PRIVATE_REPOS) $(subst $(comma),$(space),$(shell $(GO) env GOPRIVATE)))
 init-once:
-	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(value PRIVATE_REPOS)))"
 	$(foreach repo,$(PRIVATE_REPOS),\
-		$(GIT) config --global url."ssh://git@$(repo)/".insteadOf "https://$(repo)/";\
+		$(GIT) config --global url."ssh://git@$(repo)".insteadOf "https://$(repo)"; \
 	)
-else
-init-once:
-	@echo "Nothing to be done. Did you forget to set PRIVATE_REPOS?"
-endif
+	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(GOPRIVATE)))"
 
 # init-ws:
 # 	create tmp folders

--- a/examples/auth/build/package/Dockerfile
+++ b/examples/auth/build/package/Dockerfile
@@ -25,8 +25,8 @@ RUN if [ ! -z "$GITKEY" -a -e $GITKEY ]; then \
     fi
 
 RUN --mount=type=ssh \
-    make init-once init && \
-    make drop-replace && go mod tidy && \
+    make init-once init PRIVATE_MODS="$PRIVATE_MODS" && \
+    make drop-replace PRIVATE_MODS="$PRIVATE_MODS" && go mod tidy && \
     make clean build PRIVATE_MODS="$PRIVATE_MODS" VERSION="$VERSION";
 
 FROM ${BASE_IMAGE}

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -5,7 +5,7 @@ go 1.21.4
 replace github.com/cisco-open/go-lanai => ./../../../go-lanai
 
 require (
-	github.com/cisco-open/go-lanai v0.12.0
+	github.com/cisco-open/go-lanai v0.12.1-0.20240226213016-e059ad9dadea
 	github.com/pkg/errors v0.9.1
 	go.uber.org/fx v1.20.1
 )

--- a/examples/database/Makefile
+++ b/examples/database/Makefile
@@ -38,19 +38,17 @@ CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MO
 
 # init-once:
 #	Used to setup local dev environment, and should be used only once per environment.
-# 	This target assumes local environment has proper access to $PRIVATE_REPOS
-#	Required Vars:
-#		- PRIVATE_REPOS space delimited private git servers. e.g. PRIVATE_REPOS="private-github.my-domain.org"
-ifneq ($(strip $(value PRIVATE_REPOS)),)
+# 	This target assumes local environment has proper SSH access to $PRIVATE_MODS
+#	Optional Vars:
+#		- PRIVATE_MODS:	private modules and its version/branch/tag to use. comma delimited if multiple modules.
+# 		  e.g. PRIVATE_MODS="github.com/<org>/<my-private-dependency>@v0.1.0,github.my-domain.com/<org>/<repo>@0.2.1"
+init-once: PRIVATE_REPOS := $(foreach mod,$(subst $(comma),$(space),$(PRIVATE_MODS)),$(firstword $(subst @, ,$(mod))))
+init-once: GOPRIVATE := $(sort $(PRIVATE_REPOS) $(subst $(comma),$(space),$(shell $(GO) env GOPRIVATE)))
 init-once:
-	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(value PRIVATE_REPOS)))"
 	$(foreach repo,$(PRIVATE_REPOS),\
-		$(GIT) config --global url."ssh://git@$(repo)/".insteadOf "https://$(repo)/";\
+		$(GIT) config --global url."ssh://git@$(repo)".insteadOf "https://$(repo)"; \
 	)
-else
-init-once:
-	@echo "Nothing to be done. Did you forget to set PRIVATE_REPOS?"
-endif
+	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(GOPRIVATE)))"
 
 # init-ws:
 # 	create tmp folders
@@ -66,11 +64,11 @@ init-ws:
 #		- CLI_MOD_PATH the path of the go-lanai module on local file system. If provided, it would override CLI_TAG
 #		  e.g. CLI_MOD_PATH=./../go-lanai
 #		- CLI_TAG branch/tag to use to install "lanai-cli", typically same branch/tag of github.com/cisco-open/go-lanai
-#		  e.g. CLI_TAG=develop
+#		  e.g. CLI_TAG=main
 ifneq ("$(wildcard $(CLI_MOD_PATH)/go.mod)","")
 # For Contributors or Service Dev who have go-lanai checked out (either by-side or as parent) and have proper "replace" directive in go.mod
 init-cli: CLI_PKG = cmd/lanai-cli
-init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/cmd/lanai-cli
+init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/$(CLI_PKG)
 init-cli: CLI_VERSION = 0.0.0-$(shell cd $(CLI_MOD_PATH); date +"%Y%m%d%H%M%S")-$(shell $(GIT) rev-parse --short=12 HEAD || echo "SNAPSHOT")
 init-cli: print
 	@echo Installing $(CLI_MOD_PATH)/$(CLI_PKG)@$(CLI_VERSION) ...

--- a/examples/database/build/package/Dockerfile
+++ b/examples/database/build/package/Dockerfile
@@ -25,8 +25,8 @@ RUN if [ ! -z "$GITKEY" -a -e $GITKEY ]; then \
     fi
 
 RUN --mount=type=ssh \
-    make init-once init && \
-    make drop-replace && go mod tidy && \
+    make init-once init PRIVATE_MODS="$PRIVATE_MODS" && \
+    make drop-replace PRIVATE_MODS="$PRIVATE_MODS" && go mod tidy && \
     make clean build PRIVATE_MODS="$PRIVATE_MODS" VERSION="$VERSION";
 
 FROM ${BASE_IMAGE}

--- a/examples/database/go.mod
+++ b/examples/database/go.mod
@@ -5,7 +5,7 @@ go 1.20
 replace github.com/cisco-open/go-lanai => ./../../../go-lanai
 
 require (
-	github.com/cisco-open/go-lanai v0.12.0
+	github.com/cisco-open/go-lanai v0.12.1-0.20240226213016-e059ad9dadea
 	github.com/go-playground/validator/v10 v10.17.0
 	github.com/google/uuid v1.6.0
 	go.uber.org/fx v1.20.1

--- a/examples/opa/Makefile
+++ b/examples/opa/Makefile
@@ -24,6 +24,7 @@ CLI_TAG ?=
 FORCE ?=
 UPGRADE ?=
 DEV ?=
+PRIVATE_MODS ?=
 
 ## Required Variables by Local Targets
 GO ?= go
@@ -38,19 +39,18 @@ CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MO
 
 # init-once:
 #	Used to setup local dev environment, and should be used only once per environment.
-# 	This target assumes local environment has proper access to $PRIVATE_REPOS
+# 	This target assumes local environment has proper SSH access to $PRIVATE_MODS
 #	Required Vars:
-#		- PRIVATE_REPOS space delimited private git servers. e.g. PRIVATE_REPOS="private-github.my-domain.org"
-ifneq ($(strip $(value PRIVATE_REPOS)),)
+#		- PRIVATE_MODS space delimited private golang modules.
+# 		  e.g. PRIVATE_REPOS="github.com/<org>/<private-repo>"
+#			   PRIVATE_REPOS="private-github.my-domain.org/path/to/module/repo"
+init-once: PRIVATE_REPOS := $(foreach mod,$(subst $(comma),$(space),$(PRIVATE_MODS)),$(firstword $(subst @, ,$(mod))))
+init-once: GOPRIVATE := $(sort $(PRIVATE_REPOS) $(subst $(comma),$(space),$(shell $(GO) env GOPRIVATE)))
 init-once:
-	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(value PRIVATE_REPOS)))"
 	$(foreach repo,$(PRIVATE_REPOS),\
-		$(GIT) config --global url."ssh://git@$(repo)/".insteadOf "https://$(repo)/";\
+		$(GIT) config --global url."ssh://git@$(repo)".insteadOf "https://$(repo)"; \
 	)
-else
-init-once:
-	@echo "Nothing to be done. Did you forget to set PRIVATE_REPOS?"
-endif
+	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(GOPRIVATE)))"
 
 # init-ws:
 # 	create tmp folders

--- a/examples/opa/go.mod
+++ b/examples/opa/go.mod
@@ -4,4 +4,4 @@ go 1.20
 
 replace github.com/cisco-open/go-lanai => ./../../../go-lanai
 
-require github.com/cisco-open/go-lanai v0.12.0
+require github.com/cisco-open/go-lanai v0.12.1-0.20240226213016-e059ad9dadea

--- a/examples/skeleton/Makefile
+++ b/examples/skeleton/Makefile
@@ -24,6 +24,7 @@ CLI_TAG ?=
 FORCE ?=
 UPGRADE ?=
 DEV ?=
+PRIVATE_MODS ?=
 
 ## Required Variables by Local Targets
 GO ?= go
@@ -38,19 +39,18 @@ CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MO
 
 # init-once:
 #	Used to setup local dev environment, and should be used only once per environment.
-# 	This target assumes local environment has proper access to $PRIVATE_REPOS
+# 	This target assumes local environment has proper SSH access to $PRIVATE_MODS
 #	Required Vars:
-#		- PRIVATE_REPOS space delimited private git servers. e.g. PRIVATE_REPOS="private-github.my-domain.org"
-ifneq ($(strip $(value PRIVATE_REPOS)),)
+#		- PRIVATE_MODS space delimited private golang modules.
+# 		  e.g. PRIVATE_REPOS="github.com/<org>/<private-repo>"
+#			   PRIVATE_REPOS="private-github.my-domain.org/path/to/module/repo"
+init-once: PRIVATE_REPOS := $(foreach mod,$(subst $(comma),$(space),$(PRIVATE_MODS)),$(firstword $(subst @, ,$(mod))))
+init-once: GOPRIVATE := $(sort $(PRIVATE_REPOS) $(subst $(comma),$(space),$(shell $(GO) env GOPRIVATE)))
 init-once:
-	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(value PRIVATE_REPOS)))"
 	$(foreach repo,$(PRIVATE_REPOS),\
-		$(GIT) config --global url."ssh://git@$(repo)/".insteadOf "https://$(repo)/";\
+		$(GIT) config --global url."ssh://git@$(repo)".insteadOf "https://$(repo)"; \
 	)
-else
-init-once:
-	@echo "Nothing to be done. Did you forget to set PRIVATE_REPOS?"
-endif
+	$(GO) env -w GOPRIVATE="$(subst $(space),$(comma),$(strip $(GOPRIVATE)))"
 
 # init-ws:
 # 	create tmp folders

--- a/examples/skeleton/go.mod
+++ b/examples/skeleton/go.mod
@@ -4,4 +4,4 @@ go 1.20
 
 replace github.com/cisco-open/go-lanai => ./../../../go-lanai
 
-require github.com/cisco-open/go-lanai v0.12.0
+require github.com/cisco-open/go-lanai v0.12.1-0.20240226213016-e059ad9dadea


### PR DESCRIPTION
## Description

Updated Dockerfile and Makefile templates to properly initialize l environment. `make init-once` is now leveraging `PRIVATE_MODS` to property config git access and GOPRIVATE

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
