### PR TITLE
Fixed Issue with Service Makefile Template

### DIFF
--- a/cmd/lanai-cli/cmdutils/go_cmd.go
+++ b/cmd/lanai-cli/cmdutils/go_cmd.go
@@ -114,7 +114,7 @@ func FindModule(ctx context.Context, opts []GoCmdOptions, modules ...string) ([]
 }
 
 func FindPackages(ctx context.Context, opts []GoCmdOptions, modules ...string) (map[string]*GoPackage, error) {
-	cmd := "go list -json"
+	cmd := "go list -json -find"
 	for _, f := range opts {
 		f(&cmd)
 	}
@@ -397,16 +397,10 @@ func prepareTargetGoModFile(ctx context.Context) (string, error) {
 	}
 
 	// drop invalid replace
-	replaces, e := DropInvalidReplace(ctx, GoCmdModFile(tmpModFile))
+	_, e := DropInvalidReplace(ctx, GoCmdModFile(tmpModFile))
 	if e != nil {
 		return "", fmt.Errorf("error when drop invalid replaces: %v", e)
 	}
 
-	// drop require as well (we don't need to to resolve local packages
-	for _, v := range replaces {
-		if e := DropRequire(ctx, v.Old.Path, GoCmdModFile(tmpModFile)); e != nil {
-			return "", fmt.Errorf("error when dropping require %s: %v", v.Old.Path, e)
-		}
-	}
 	return tmpModFile, nil
 }

--- a/cmd/lanai-cli/initcmd/Makefile.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile.tmpl
@@ -32,6 +32,7 @@ CLI ?= lanai-cli
 
 INIT_TMP_DIR = $(TMP_DIR)/init
 CLI_GOMOD_FILE = $(INIT_TMP_DIR)/go.mod
+CLI_MOD_RELATIVE_PATH = $(shell $(GO) list -f='{{or .Replace ""}}' -m $(CLI_MOD))
 CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MOD)`)
 
 ## Local Targets
@@ -65,13 +66,13 @@ init-ws:
 #		  e.g. CLI_MOD_PATH=./../go-lanai
 #		- CLI_TAG branch/tag to use to install "lanai-cli", typically same branch/tag of github.com/cisco-open/go-lanai
 #		  e.g. CLI_TAG=main
-ifneq ("$(wildcard $(CLI_MOD_PATH)/go.mod)","")
+ifneq ("$(and $(CLI_MOD_RELATIVE_PATH), $(wildcard $(CLI_MOD_PATH)/go.mod))", "")
 # For Contributors or Service Dev who have go-lanai checked out (either by-side or as parent) and have proper "replace" directive in go.mod
 init-cli: CLI_PKG = cmd/lanai-cli
 init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/$(CLI_PKG)
-init-cli: CLI_VERSION = 0.0.0-$(shell cd $(CLI_MOD_PATH); date +"%Y%m%d%H%M%S")-$(shell $(GIT) rev-parse --short=12 HEAD || echo "SNAPSHOT")
+init-cli: CLI_VERSION = 0.0.0-$(shell date +"%Y%m%d%H%M%S")-$(shell cd $(CLI_MOD_PATH); $(GIT) rev-parse --short=12 HEAD || echo "SNAPSHOT")
 init-cli: print
-	@echo Installing $(CLI_MOD_PATH)/$(CLI_PKG)@$(CLI_VERSION) ...
+	@echo Installing $(CLI_PKG_PATH)@$(CLI_VERSION) including local modifications ...
 	@cd $(CLI_MOD_PATH); $(GO) install -ldflags="-X main.BuildVersion=$(CLI_VERSION)" $(CLI_PKG_PATH)
 
 else
@@ -94,8 +95,9 @@ init: init-cli
 	$(CLI) init -o ./ $(if $(filter true True TRUE,$(FORCE)),--force) $(if $(filter true True TRUE,$(UPGRADE)),--upgrade)
 
 print:
+	@echo "WORK_DIR:    $(WORK_DIR)"
 	@echo "CLI_VERSION:  $(CLI_VERSION)"
 	@echo "CLI_PKG_PATH: $(CLI_PKG_PATH)"
 	@echo "CLI_TAG:      $(CLI_TAG)"
+	@echo "CLI_MOD_RELATIVE_PATH: $(CLI_MOD_RELATIVE_PATH)"
 	@echo "CLI_MOD_PATH: $(CLI_MOD_PATH)"
-


### PR DESCRIPTION
## Description

The Makefile template had these issues:

1. Due to changes to the `go list` command in golang 1.21, the `make init` command may fail due to missing dependency in go.mod.
2. The `make init-cli` command was not handling the situation where go-lanai is not replaced by a local copy in the go.mod file.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
