### PR TITLE
Fix Makefile Issue Caused by Golang 1.21

### DIFF
--- a/cmd/lanai-cli/cmdutils/go_cmd.go
+++ b/cmd/lanai-cli/cmdutils/go_cmd.go
@@ -397,9 +397,30 @@ func prepareTargetGoModFile(ctx context.Context) (string, error) {
 	}
 
 	// drop invalid replace
-	_, e := DropInvalidReplace(ctx, GoCmdModFile(tmpModFile))
+	replaces, e := DropInvalidReplace(ctx, GoCmdModFile(tmpModFile))
 	if e != nil {
 		return "", fmt.Errorf("error when drop invalid replaces: %v", e)
+	}
+
+	// drop require as well
+	// This is because when there is a "replace" directive in the go.mod, the go.sum
+	// file usually doesn't include the entries that were "replaced" by local copy.
+	// i.e. running "go mod tidy" on such a go.mod file will result in the replaced entry
+	// being removed from go.sum.
+	// When the go.sum is in this state, the result of the "go list" command depends on
+	// if the "replace" directive points to a valid local directory.
+	// If the local directory doesn't exist, the command will result in error.
+	// If the non-existent "replace" directive is dropped, but the "require" directive is not dropped,
+	// we would get an error complaining about the missing go.sum entry.
+	// Therefor we drop the "require" directive as well.
+	// This is ok because how we intend to use the resulting go.mod file.
+	// We will use this go.mod to find packages in the current service. So its dependencies are not important.
+	// However, we need to be careful to not use go commands that resolves dependencies.
+	// For example, in FindPackages we use the "-find" tag in the "go list -json -find" to not resolve dependencies.
+	for _, v := range replaces {
+		if e := DropRequire(ctx, v.Old.Path, GoCmdModFile(tmpModFile)); e != nil {
+			return "", fmt.Errorf("error when dropping require %s: %v", v.Old.Path, e)
+		}
 	}
 
 	return tmpModFile, nil

--- a/cmd/lanai-cli/cmdutils/go_cmd.go
+++ b/cmd/lanai-cli/cmdutils/go_cmd.go
@@ -114,7 +114,7 @@ func FindModule(ctx context.Context, opts []GoCmdOptions, modules ...string) ([]
 }
 
 func FindPackages(ctx context.Context, opts []GoCmdOptions, modules ...string) (map[string]*GoPackage, error) {
-	cmd := "go list -json"
+	cmd := "go list -json -find"
 	for _, f := range opts {
 		f(&cmd)
 	}
@@ -397,16 +397,10 @@ func prepareTargetGoModFile(ctx context.Context) (string, error) {
 	}
 
 	// drop invalid replace
-	replaces, e := DropInvalidReplace(ctx, GoCmdModFile(tmpModFile))
+	_, e := DropInvalidReplace(ctx, GoCmdModFile(tmpModFile))
 	if e != nil {
 		return "", fmt.Errorf("error when drop invalid replaces: %v", e)
 	}
 
-	// drop require as well (we don't need to to resolve local packages
-	for _, v := range replaces {
-		if e := DropRequire(ctx, v.Old.Path, GoCmdModFile(tmpModFile)); e != nil {
-			return "", fmt.Errorf("error when dropping require %s: %v", v.Old.Path, e)
-		}
-	}
 	return tmpModFile, nil
 }

--- a/cmd/lanai-cli/initcmd/Makefile-Build.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile-Build.tmpl
@@ -96,12 +96,3 @@ $(GEN_LIST):
 resource@{{ .Output }}:
 	cp -rf {{ .Pattern }} $(DESTDIR)/{{ .Output }}
 	{{ end }}
-
-# Runs contract-verifier precheck to verify service contract against CPX guidelines
-contract:
-	ccv precheck
-
-# Runs contract-verify to check if implementation matches the contract
-# precheck disabled as we expect pipeline to perform that separately via preceding target
-verify-contract:
-	ccv check  --enable-precheck=false

--- a/cmd/lanai-cli/initcmd/Makefile.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile.tmpl
@@ -32,6 +32,7 @@ CLI ?= lanai-cli
 
 INIT_TMP_DIR = $(TMP_DIR)/init
 CLI_GOMOD_FILE = $(INIT_TMP_DIR)/go.mod
+CLI_MOD_RELATIVE_PATH = $(shell $(GO) list -f='{{or .Replace ""}}' -m $(CLI_MOD))
 CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MOD)`)
 
 ## Local Targets
@@ -65,13 +66,13 @@ init-ws:
 #		  e.g. CLI_MOD_PATH=./../go-lanai
 #		- CLI_TAG branch/tag to use to install "lanai-cli", typically same branch/tag of github.com/cisco-open/go-lanai
 #		  e.g. CLI_TAG=main
-ifneq ("$(wildcard $(CLI_MOD_PATH)/go.mod)","")
+ifneq ("$(and $(CLI_MOD_RELATIVE_PATH), $(wildcard $(CLI_MOD_PATH)/go.mod))", "")
 # For Contributors or Service Dev who have go-lanai checked out (either by-side or as parent) and have proper "replace" directive in go.mod
 init-cli: CLI_PKG = cmd/lanai-cli
 init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/$(CLI_PKG)
-init-cli: CLI_VERSION = 0.0.0-$(shell cd $(CLI_MOD_PATH); date +"%Y%m%d%H%M%S")-$(shell $(GIT) rev-parse --short=12 HEAD || echo "SNAPSHOT")
+init-cli: CLI_VERSION = 0.0.0-$(shell date +"%Y%m%d%H%M%S")-$(shell cd $(CLI_MOD_PATH); $(GIT) rev-parse --short=12 HEAD || echo "SNAPSHOT")
 init-cli: print
-	@echo Installing $(CLI_MOD_PATH)/$(CLI_PKG)@$(CLI_VERSION) ...
+	@echo Installing $(CLI_PKG_PATH)@$(CLI_VERSION) including local modifications ...
 	@cd $(CLI_MOD_PATH); $(GO) install -ldflags="-X main.BuildVersion=$(CLI_VERSION)" $(CLI_PKG_PATH)
 
 else
@@ -94,8 +95,9 @@ init: init-cli
 	$(CLI) init -o ./ $(if $(filter true True TRUE,$(FORCE)),--force) $(if $(filter true True TRUE,$(UPGRADE)),--upgrade)
 
 print:
+	@echo "WORK_DIR:    $(WORK_DIR)"
 	@echo "CLI_VERSION:  $(CLI_VERSION)"
 	@echo "CLI_PKG_PATH: $(CLI_PKG_PATH)"
 	@echo "CLI_TAG:      $(CLI_TAG)"
+	@echo "CLI_MOD_RELATIVE_PATH: $(CLI_MOD_RELATIVE_PATH)"
 	@echo "CLI_MOD_PATH: $(CLI_MOD_PATH)"
-

--- a/cmd/lanai-cli/initcmd/Makefile.tmpl
+++ b/cmd/lanai-cli/initcmd/Makefile.tmpl
@@ -33,7 +33,7 @@ CLI ?= lanai-cli
 INIT_TMP_DIR = $(TMP_DIR)/init
 CLI_GOMOD_FILE = $(INIT_TMP_DIR)/go.mod
 CLI_MOD_RELATIVE_PATH = $(shell $(GO) list -f='{{or .Replace ""}}' -m $(CLI_MOD))
-CLI_MOD_PATH ?= $(shell realpath `$(GO) list -f='{{or .Replace ""}}' -m $(CLI_MOD)`)
+CLI_MOD_PATH ?= $(if $(CLI_MOD_RELATIVE_PATH), $(shell realpath $(CLI_MOD_RELATIVE_PATH)), "")
 
 ## Local Targets
 
@@ -66,7 +66,7 @@ init-ws:
 #		  e.g. CLI_MOD_PATH=./../go-lanai
 #		- CLI_TAG branch/tag to use to install "lanai-cli", typically same branch/tag of github.com/cisco-open/go-lanai
 #		  e.g. CLI_TAG=main
-ifneq ("$(and $(CLI_MOD_RELATIVE_PATH), $(wildcard $(CLI_MOD_PATH)/go.mod))", "")
+ifneq ("$(and $(CLI_MOD_PATH), $(wildcard $(CLI_MOD_PATH)/go.mod))", "")
 # For Contributors or Service Dev who have go-lanai checked out (either by-side or as parent) and have proper "replace" directive in go.mod
 init-cli: CLI_PKG = cmd/lanai-cli
 init-cli: CLI_PKG_PATH = $(CLI_MOD_PATH)/$(CLI_PKG)

--- a/cmd/lanai-cli/initcmd/README.md
+++ b/cmd/lanai-cli/initcmd/README.md
@@ -1,0 +1,215 @@
+# Lanai-CLI Init and GNU Make
+
+This package provides a set of templates for `GNU Make`. Together with the `lanai-cli`. They provide an opinionated way
+that automates common tasks needed in the software development lifecycle.
+
+## An Opinionated CI/CD Approach
+
+## Bootstrap a Project
+
+To bootstrap a project from scratch, copy the [`Makefile.tmpl`](Makefile.tmpl) into your project root directory, and rename 
+it to `Makefile`. This `Makefile` contains the targets that can bootstrap the rest of the targets you will need for your
+development needs.
+
+### Setting Up Local Environment
+
+```make init-once```
+
+This targets is used to set up your local development environment. You should run this target if your project uses any
+private modules in its dependency. A private module is a module that is not publicly available. 
+
+This target takes the `PRIVATE_MODS` argument. This argument takes a comma separated list of private modules.
+
+```make init-once PRIVATE_MODS="github.com/<org>/<my-private-dependency>@v0.1.0,github.my-domain.com/<org>/<repo>@0.2.1```
+
+Running this target will configure your `git` command to use `ssh` instead of `https` to access these module repos. It will
+also append these module repos to the `GOPRIVATE` variable so that `go` does not use the public Go module proxy of the public
+checksum database.
+
+If your project does not use any private modules, you do not need to run this target.
+
+### Generate Project Specific Make File and Docker File
+
+```make init```
+
+Pre-requisite:
+1. a `go.mod` file that has `go-lanai` as a required module.
+2. a `Module.yml` that describes your project. The `Module.yml` can have the following entries
+```yaml
+name: europa # name of the project
+
+execs: # your project's executables. these entries will be used to generate the dockerlaunch file
+  europa:
+    main: cmd/europa/main.go 
+    port: 8080 # specify a port to indicate this binary represents a web app. 
+  migrate:
+    main: cmd/europa/migrate.go
+    type: migrator # specify migrator type to indicate this binary is responsible for database migration.
+
+generates: # packages that have the golang generate directive. they will be used to generate Makefile target for building the project
+  - path: "pkg/swagger"
+  - path: "pkg/security/example"
+
+resources: # resources that should be published together with the binary. they will be used to generate Makefile target for building the project
+  - pattern: "configs" # this is the pattern to find them in the source directory
+    output: "configs" # this is the directory to copy them to in the dist directory 
+  - pattern: "web"
+    output: "web"
+```
+
+This target installs the `lanai-cli` command line tool, and invoke the `lanai-cli init` command to generate your project
+specific make files and docker files. 
+
+#### Installing `lanai-cli`
+
+This is done automatically by calling the ```make init-cli``` sub target.
+
+This installs the `lanai-cli`. This command handles a variety of cases to accommodate different use cases.
+
+If the `go.mod` has a `replace` directive that points `go-lanai` to a local copy. This case is most common for developers
+who have local modification to `go-lanai`. In this case, this target will install `lanai-cli` from the local checked out
+location of `go-lanai`. 
+
+If the local location is not valid, it will install `go-lanai` according to the required version.
+
+If the `go.mod` does not have a `replace` directive for `go-lanai`, it will install according to the required version. 
+
+Except when installing using local copy via the `replace` directive, you can use the `CLI_TAG` argument to override the
+version of `lanai-cli` to be installed. The `CLI_TAG` argument can be either a branch name or a tag in the `go-lanai` repo.
+
+i.e. `make init-cli CLI_TAG=main`.
+
+#### Invoking `lanai-cli init`
+
+After installing `lanai-cli`, the `make init` target generates a set of files based on the information from `Module.yml`
+by invoking the `lanai-cli init` command.
+
+It will generate the following files:
+* `Makefile-Build` This file contains the targets specific to your project. Such as executables to build, resources to copy.
+* `Makefile-Generated` This file contains targets that are usually used by CI/CD.
+* `Dockerfile` This file will be used to build the image for your service. It will expose ports listed in the `Module.yml` file.
+* `dockerlaunch.sh` The entry point of the docker image. It will use the executable listed in the `Module.yml` file.
+
+The recommended practice is to check in `Makefile-Build`, `Dockerfile` and `dockerlaunch.sh`. These files are specific
+to your project, and you may want to modify them as you need. `make init` will not overwrite existing files, so your 
+changes can persist. If you updated `Module.yml` and want to re-generate them. You need to use the `FORCE` flag. i.e
+`make init FORCE=true`
+
+`Makefile-Generated` is project agnostic. It's not expected to be checked in and will be re-generated during the CI/CD process.
+
+## Development
+
+### Running Tests and Linters
+
+The following targets are found in `Makefile-Build` which is generated based on the `Makefile-Build.tmpl`.
+
+```make test``` 
+
+Runs tests and produce test coverage report. You should use this command in PR verification as well so any PR verification
+issue is repeatable.
+
+```make lint```
+
+Invoke `go vet` and `golangci-lint` linter.
+
+### Making Builds
+
+```make build```
+
+This command will create a `dist` folder. This folder will contain the executable binaries and any files that the binaries
+needs for execution.
+
+This target takes `VERSION` and `PRIVATE_MODS` arguments. `VERSION` is the version number you want to give to this build.
+The `PRIVATE_MODS` represents the private modules in your project's dependency. The build tool will look up the entries in
+`PRIVATE_MODS` in your service's `go.mod` and records their versions. All the information will be set into variables in the
+binary via ldflags, so that the binaries can report its own metadata.
+
+The following variable will be set:
+
+```
+	BuildVersion
+	BuildTime
+	BuildHash
+	BuildDeps
+```
+
+See the bootstrap package and `pkg/bootstrap/build_info.go` on how to access these variables in your binary.
+
+```make clean```
+
+Cleans the `dist` directory.
+
+## PR Verification
+
+PR verification needs to check out the PR branch and ensure it runs successfully. Same as on a development environment,
+```make init``` needs to be executed to bootstrap `lanai-cli` and `GNU Make`. Usually we don't expect `go-lanai` to be
+checked out in this environment. So ```make init``` will use the version of `go-lanai` in the go.mod file. If you need
+a specific version of the `lanai-cli`, you can use the `CLI_TAG` argument.
+
+The ```make verify``` target is designed for the PR verification process according to our approach to private modules. 
+This target takes `PRIVATE_MODS`. Use this argument to specify the private module versions you want to verify this PR with.
+i.e. `make verify PRIVATE_MODS=github.com/<org>/<my-private-dependency>@develop`. If your project does not use private modules,
+or your private module is not being developed in tandem (i.e. it has a fixed version in `go.mod` instead of a `replace` directive),
+you can omit this argument. The `make verify` target will execute the following steps.
+
+1. Run `make pre` to create a git tag `tmp/pr-verify`
+2. Run `make update-dependency` to update module dependency based on `PRIVATE_MODS`. This is done by invoking `lanai-cli deps --modules=$(PRIVATE_MODS)` This 
+will modify the version of the private modules in `go.mod` according to the value of `PRIVATE_MODS`. If `UPDATE_DEPS_MARK` is
+passed, a git `tag` will be created to save a record of this change.
+3. Run `make drop-replace` to drop the `replace` directive based on `PRIVATE_MODS`. This is done by invoking `lanai-cli drop-replace --modules=$(PRIVATE_MODS)`
+This will drop the `replace` directives for the `PRIVATE_MODS`. If `DROP_REPLACE_MARK` is passed, a git tag will be created to save
+a record of this change.
+4. Run `make clean`.  
+5. Run `make test`. 
+6. Run `make lint`.
+7. Run `make build`. The `PRIVATE_MODS` argument will pass through to this target.
+8. Run `make report`. This will generate the test report
+9. RUN `make post` to revert the code to the git tag `tmp/pre-verify`  
+
+Note in step 2 `lanai-cli` will drop invalid `replace` directive before update dependency. It will run `go mod tidy` after
+updating dependency, and add the `replace` directive back.
+
+## Build For Distribution
+
+### Build
+
+Similar to PR verification, making a distribution build involves checking out a copy of the project and build it with 
+specific version of the private modules. In addition, source code needs to be tagged so that there's a record of the
+source code for this build.
+
+The ```make dist``` target is designed for this purpose according to our approach
+to private modules. This command also takes the `PRIVATE_MODS` argument. i.e. `make dist PRIVATE_MODS=github.com/<org>/<my-private-dependency>@develop VERSION=4.0.0-20`
+This command executes the following steps:
+
+1. Run `make pre` to create a git tag `tmp/pre-dist`
+2. Run `make update-dependency` to update module dependency based on `PRIVATE_MODS`. This is done by invoking `lanai-cli deps --modules=$(PRIVATE_MODS)` This
+   will modify the version of the private modules in `go.mod` according to the value of `PRIVATE_MODS`. A git tag will be created to save a record of this change.
+3. Run `make drop-replace` to drop the `replace` directive based on `PRIVATE_MODS`. This is done by invoking `lanai-cli drop-replace --modules=$(PRIVATE_MODS)`
+   This will drop the `replace` directives for the `PRIVATE_MODS`. A git tag will be created to save
+   a record of this change.
+4. Run `make clean`.
+5. Run `make test`.
+6. Run `make pre-build-docker` to make sure the code is at the git tag created by step 3. 
+7. Run `make build-docker`. This command trigger the `docker` command to build a docker image. The image is built using
+the `Dockerfile`. The `Dockerfile` uses a builder pattern, so that it will copy the source code into the builder.
+The `make build` command will be run inside the builder to produce the desired distribution package.
+8. Run `make post-dist` to revert the code to the git tab `tmp/pre-dist`. Create a release tag `v$(VERSION)` using the tag
+created in step 3. Optionally merge back to the source branch by providing the `SRC_BRANCH` flag.
+
+### Publish
+
+Use the ```make publish``` command to publish the image to docker hub. This should be run after `make dist`.
+For example, after `make dist PRIVATE_MODS=github.com/<org>/<my-private-dependency>@develop VERSION=4.0.0-20)` 
+run `make publish VERSION=4.0.0-20`. This commands executes the following steps:
+
+1. Run `make push-docker` to push the image to docker registry. The required args are `DOCKER_TAG` and `DOCKER_REPO`. `DOCKER_TAG` will default to `$(VERSION)`
+`DOCKER_REPO` will default to `registry-1.docker.io`. 
+2. Run `git-push-tag` to push the release tag created by `make dist`.
+
+
+
+
+
+
+
+

--- a/cmd/lanai-cli/initcmd/README.md
+++ b/cmd/lanai-cli/initcmd/README.md
@@ -1,22 +1,43 @@
 # Lanai-CLI Init and GNU Make
 
-This package provides a set of templates for `GNU Make`. Together with the `lanai-cli`. They provide an opinionated way
-that automates common tasks needed in the software development lifecycle.
+This package provides a set of templates for `GNU Make`. Together with `lanai-cli`, they provide an opinionated way
+that automates common software development tasks.
 
-## An Opinionated CI/CD Approach
+## An Opinionated Approach
+
+The commands and processes described below represents an opinionated approach to software development lifecycle. It addresses
+the case where multiple projects are developed in parallel. For example, a team could be developing a service and a library in
+tandem, where the service is dependent on the library. In this document, you will see the library in this example being referred to
+as `PRIVATE_MODS`, which stands for "private module". It signifies this module is under development (i.e. private to the development team).
+You can still use this pattern if your library module is a public repository but being developed in parallel.
+
+In a project with one or more private modules, our workflow is the following:
+
+1. Developers will check out both the service project and the private modules.
+2. Service project's `go.mod` file will require the private modules by branch.
+3. Service project's `go.mod` file will have `replace` directives to point to checked out copies of the private modules.
+4. Developers are expected to check in the `go.mod` file with the `replace` directive.
+5. During the CI/CD process, the dependency for the private modules are updated to the head of the specified branch, 
+and the `replace` directives in the `go.mod` file are dropped.
+6. When a build is published, a copy of the code with the modified `go.mod` is version tagged and pushed.
+
+This process allows developers to work on the service and library project with ease, while allowing the CI/CD process
+to build against the expected code base.
+
+If your project does not have any private modules, simply omit the `PRIVATE_MODS` arguments in the commands.
 
 ## Bootstrap a Project
 
 To bootstrap a project from scratch, copy the [`Makefile.tmpl`](Makefile.tmpl) into your project root directory, and rename 
-it to `Makefile`. This `Makefile` contains the targets that can bootstrap the rest of the targets you will need for your
-development needs.
+it to `Makefile`. This `Makefile` contains the targets that can bootstrap the rest of the targets needed during the development
+lifecycle.
 
 ### Setting Up Local Environment
 
 ```make init-once```
 
-This targets is used to set up your local development environment. You should run this target if your project uses any
-private modules in its dependency. A private module is a module that is not publicly available. 
+This target is used to set up your local development environment. You should run this target if your project uses any
+private modules, and the private module repositories are not publicly accessible. 
 
 This target takes the `PRIVATE_MODS` argument. This argument takes a comma separated list of private modules.
 
@@ -38,7 +59,7 @@ Pre-requisite:
 ```yaml
 name: europa # name of the project
 
-execs: # your project's executables. these entries will be used to generate the dockerlaunch file
+execs: # your project's executables. these entries will be used to generate the dockerlaunch.sh file
   europa:
     main: cmd/europa/main.go 
     port: 8080 # specify a port to indicate this binary represents a web app. 
@@ -46,31 +67,34 @@ execs: # your project's executables. these entries will be used to generate the 
     main: cmd/europa/migrate.go
     type: migrator # specify migrator type to indicate this binary is responsible for database migration.
 
-generates: # packages that have the golang generate directive. they will be used to generate Makefile target for building the project
+generates: # packages that have the golang generate directive. they will be used to generate Makefile target that triggers the go generate directive.
   - path: "pkg/swagger"
   - path: "pkg/security/example"
 
-resources: # resources that should be published together with the binary. they will be used to generate Makefile target for building the project
+resources: # resources that should be published together with the binary. they will be used to generate Makefile target for copying the resources into the build
   - pattern: "configs" # this is the pattern to find them in the source directory
     output: "configs" # this is the directory to copy them to in the dist directory 
   - pattern: "web"
     output: "web"
 ```
 
-This target installs the `lanai-cli` command line tool, and invoke the `lanai-cli init` command to generate your project
-specific make files and docker files. 
+This target does the following:
+1. Installs the `lanai-cli` command line tool. 
+2. Invoke the `lanai-cli init` command to generate make files and docker files specific to your project.
+
+The following sections will describe these two steps in detail.
 
 #### Installing `lanai-cli`
 
-This is done automatically by calling the ```make init-cli``` sub target.
+`make init` installs the `lanai-cli` command line tool by calling the ```make init-cli``` sub-target which handles a 
+variety of use cases.
 
-This installs the `lanai-cli`. This command handles a variety of cases to accommodate different use cases.
+First case is where the `go.mod` file has a `replace` directive that points `go-lanai` to a local copy. This case is most 
+common for developers who have local modification to `go-lanai`. In this case, this target will install `lanai-cli` from 
+the local checked out location of `go-lanai`. 
 
-If the `go.mod` has a `replace` directive that points `go-lanai` to a local copy. This case is most common for developers
-who have local modification to `go-lanai`. In this case, this target will install `lanai-cli` from the local checked out
-location of `go-lanai`. 
-
-If the local location is not valid, it will install `go-lanai` according to the required version.
+If the local location is not valid, it will install `go-lanai` according to the required version. This is most common in 
+the CI/CD pipeline.
 
 If the `go.mod` does not have a `replace` directive for `go-lanai`, it will install according to the required version. 
 
@@ -101,12 +125,12 @@ changes can persist. If you updated `Module.yml` and want to re-generate them. Y
 
 ### Running Tests and Linters
 
-The following targets are found in `Makefile-Build` which is generated based on the `Makefile-Build.tmpl`.
+The following targets are found in `Makefile-Build` which is generated based on `Makefile-Build.tmpl`.
 
 ```make test``` 
 
-Runs tests and produce test coverage report. You should use this command in PR verification as well so any PR verification
-issue is repeatable.
+Runs tests and produce test coverage report. This is the same target used in PR verification as well so any verification
+issue is repeatable locally.
 
 ```make lint```
 
@@ -119,10 +143,10 @@ Invoke `go vet` and `golangci-lint` linter.
 This command will create a `dist` folder. This folder will contain the executable binaries and any files that the binaries
 needs for execution.
 
-This target takes `VERSION` and `PRIVATE_MODS` arguments. `VERSION` is the version number you want to give to this build.
-The `PRIVATE_MODS` represents the private modules in your project's dependency. The build tool will look up the entries in
-`PRIVATE_MODS` in your service's `go.mod` and records their versions. All the information will be set into variables in the
-binary via ldflags, so that the binaries can report its own metadata.
+This target takes `VERSION` and `PRIVATE_MODS` arguments. `VERSION` is the version number you want to give to this build. 
+`PRIVATE_MODS` represents the private modules in your project's dependency. The build tool will look up the entries in
+`PRIVATE_MODS` in your service's `go.mod` and record their versions. All the information will be set into variables in the
+binary via ldflags, so that the binary can report its own build info.
 
 The following variable will be set:
 
@@ -133,7 +157,8 @@ The following variable will be set:
 	BuildDeps
 ```
 
-See the bootstrap package and `pkg/bootstrap/build_info.go` on how to access these variables in your binary.
+See the bootstrap package and [pkg/bootstrap/build_info.go](../../../pkg/bootstrap/build_info.go) on how to access these 
+variables in your binary.
 
 ```make clean```
 
@@ -141,23 +166,25 @@ Cleans the `dist` directory.
 
 ## PR Verification
 
-PR verification needs to check out the PR branch and ensure it runs successfully. Same as on a development environment,
+PR verification needs to check out the PR branch and ensure it builds and tests successfully. Same as on a development environment,
 ```make init``` needs to be executed to bootstrap `lanai-cli` and `GNU Make`. Usually we don't expect `go-lanai` to be
-checked out in this environment. So ```make init``` will use the version of `go-lanai` in the go.mod file. If you need
+checked out in this environment. So ```make init``` will use the version of `go-lanai` in the `go.mod` file. If you need
 a specific version of the `lanai-cli`, you can use the `CLI_TAG` argument.
 
-The ```make verify``` target is designed for the PR verification process according to our approach to private modules. 
-This target takes `PRIVATE_MODS`. Use this argument to specify the private module versions you want to verify this PR with.
+The ```make verify``` target is designed to facilitate the PR verification process. 
+This target takes `PRIVATE_MODS` as an argument. You can use this argument to specify the private module versions you want to verify this PR with.
 i.e. `make verify PRIVATE_MODS=github.com/<org>/<my-private-dependency>@develop`. If your project does not use private modules,
 or your private module is not being developed in tandem (i.e. it has a fixed version in `go.mod` instead of a `replace` directive),
-you can omit this argument. The `make verify` target will execute the following steps.
+you can omit this argument. 
+
+This command executes the following steps.
 
 1. Run `make pre` to create a git tag `tmp/pr-verify`
 2. Run `make update-dependency` to update module dependency based on `PRIVATE_MODS`. This is done by invoking `lanai-cli deps --modules=$(PRIVATE_MODS)` This 
-will modify the version of the private modules in `go.mod` according to the value of `PRIVATE_MODS`. If `UPDATE_DEPS_MARK` is
-passed, a git `tag` will be created to save a record of this change.
+will modify the version of the private modules in `go.mod` according to the value of `PRIVATE_MODS`. If the `UPDATE_DEPS_MARK` argument is
+provided, a git `tag` will be created to save a record of this change.
 3. Run `make drop-replace` to drop the `replace` directive based on `PRIVATE_MODS`. This is done by invoking `lanai-cli drop-replace --modules=$(PRIVATE_MODS)`
-This will drop the `replace` directives for the `PRIVATE_MODS`. If `DROP_REPLACE_MARK` is passed, a git tag will be created to save
+This will drop the `replace` directives for the `PRIVATE_MODS`. If the `DROP_REPLACE_MARK` argument is passed, a git tag will be created to save
 a record of this change.
 4. Run `make clean`.  
 5. Run `make test`. 
@@ -167,7 +194,7 @@ a record of this change.
 9. RUN `make post` to revert the code to the git tag `tmp/pre-verify`  
 
 Note in step 2 `lanai-cli` will drop invalid `replace` directive before update dependency. It will run `go mod tidy` after
-updating dependency, and add the `replace` directive back.
+updating dependency, and add the `replace` directive back. All the tags created are local and not pushed upstream.
 
 ## Build For Distribution
 
@@ -177,8 +204,9 @@ Similar to PR verification, making a distribution build involves checking out a 
 specific version of the private modules. In addition, source code needs to be tagged so that there's a record of the
 source code for this build.
 
-The ```make dist``` target is designed for this purpose according to our approach
-to private modules. This command also takes the `PRIVATE_MODS` argument. i.e. `make dist PRIVATE_MODS=github.com/<org>/<my-private-dependency>@develop VERSION=4.0.0-20`
+The ```make dist``` target is designed for this purpose. This command also takes the `PRIVATE_MODS` argument. 
+i.e. `make dist PRIVATE_MODS=github.com/<org>/<my-private-dependency>@develop VERSION=4.0.0-20`
+
 This command executes the following steps:
 
 1. Run `make pre` to create a git tag `tmp/pre-dist`
@@ -191,10 +219,13 @@ This command executes the following steps:
 5. Run `make test`.
 6. Run `make pre-build-docker` to make sure the code is at the git tag created by step 3. 
 7. Run `make build-docker`. This command trigger the `docker` command to build a docker image. The image is built using
-the `Dockerfile`. The `Dockerfile` uses a builder pattern, so that it will copy the source code into the builder.
-The `make build` command will be run inside the builder to produce the desired distribution package.
+the `Dockerfile`. The `Dockerfile` uses a builder pattern. Source code will be copied into the builder and 
+the `make build` command will be run inside the builder to produce the desired distribution package. See [Dockerfile.tmpl](Dockerfile.tmpl) 
+for more details.
 8. Run `make post-dist` to revert the code to the git tab `tmp/pre-dist`. Create a release tag `v$(VERSION)` using the tag
-created in step 3. Optionally merge back to the source branch by providing the `SRC_BRANCH` flag.
+created in step 3. Optionally merge back to the source branch if the `SRC_BRANCH` argument is provided.
+
+All the tags created are local and not pushed upstream.
 
 ### Publish
 
@@ -205,11 +236,3 @@ run `make publish VERSION=4.0.0-20`. This commands executes the following steps:
 1. Run `make push-docker` to push the image to docker registry. The required args are `DOCKER_TAG` and `DOCKER_REPO`. `DOCKER_TAG` will default to `$(VERSION)`
 `DOCKER_REPO` will default to `registry-1.docker.io`. 
 2. Run `git-push-tag` to push the release tag created by `make dist`.
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Description

The Makefile template had these issues:

1.  Due to changes to the go list command in golang 1.21, the make init command may fail due to missing dependency in go.mod.
2. The make init-cli command was not handling the situation where go-lanai is not replaced by a local copy in the go.mod file.
3. Added documentation for the make file templates.


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
