### PR TITLE
Fixed a typo causing `data` packages fail to build when CGO_ENABLED=0

### DIFF
--- a/pkg/data/repo/gorm_options.go
+++ b/pkg/data/repo/gorm_options.go
@@ -16,7 +16,6 @@
 
 package repo
 
-import "C"
 import (
     "fmt"
     "github.com/cisco-open/go-lanai/pkg/data"


### PR DESCRIPTION
## Description

`CGO_ENABLED=0 make test` fails because there is a typo in `pkg/data/repo` files that accidentally imports "C" lib.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
