### PR TITLE
fixed dsync mock in test package

### DIFF
--- a/test/mocks/dsyncmock/simple_sync_manager.go
+++ b/test/mocks/dsyncmock/simple_sync_manager.go
@@ -27,7 +27,7 @@ type SimpleSyncManagerMock struct {}
 
 type NoopOut struct {
 	fx.Out
-	TestSyncManager dsync.SyncManager `group:"test"`
+	TestSyncManager dsync.SyncManager `group:"dsync"`
 }
 
 func ProvideNoopSyncManager() NoopOut {

--- a/test/mocks/dsyncmock/sync_manager_test.go
+++ b/test/mocks/dsyncmock/sync_manager_test.go
@@ -18,24 +18,27 @@ package dsyncmock
 
 import (
 	"context"
+	"github.com/cisco-open/go-lanai/pkg/dsync"
 	"github.com/cisco-open/go-lanai/test"
+	"github.com/cisco-open/go-lanai/test/apptest"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
+	"go.uber.org/fx"
 	"testing"
 )
 
 func TestSyncManager(t *testing.T) {
 	test.RunTest(context.Background(), t,
+		apptest.Bootstrap(),
+		apptest.WithModules(dsync.Module),
+		apptest.WithFxOptions(fx.Provide(ProvideNoopSyncManager)),
 		test.GomegaSubTest(SubTestNoopSyncManager(), "TestNoopSyncManager"),
 	)
 }
 
 func SubTestNoopSyncManager() test.GomegaSubTestFunc {
 	return func(ctx context.Context, t *testing.T, g *gomega.WithT) {
-		out := ProvideNoopSyncManager()
-		manager := out.TestSyncManager
-		l, e := manager.Lock("test-key")
-		g.Expect(e).To(Succeed())
+		l := dsync.LockWithKey("test-key")
 		g.Expect(l.Key()).To(BeEquivalentTo("test-key"))
 		g.Expect(l.Lock(ctx)).To(Succeed())
 		g.Expect(l.TryLock(ctx)).To(Succeed())


### PR DESCRIPTION
## Description

`dsyncmock` package is using wrong FX group, causing tests using this package fails

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
