### PR TITLE
fixed http client package's error message formatting

### DIFF
--- a/pkg/integrate/httpclient/client.go
+++ b/pkg/integrate/httpclient/client.go
@@ -76,7 +76,7 @@ func (c *client) WithService(service string, opts ...SDOptions) (Client, error) 
 
 	instancer, e := c.sdClient.Instancer(service)
 	if e != nil {
-		return nil, NewNoEndpointFoundError("cannot create client with service name: %v", e)
+		return nil, NewNoEndpointFoundError(fmt.Errorf("cannot create client with service name: %s", service), e)
 	}
 
 	defaultOpts := func(opts *SDOption) {
@@ -86,7 +86,7 @@ func (c *client) WithService(service string, opts ...SDOptions) (Client, error) 
 	opts = append([]SDOptions{defaultOpts}, opts...)
 	targetResolver, e := NewSDTargetResolver(instancer, opts...)
 	if e != nil {
-		return nil, NewNoEndpointFoundError("cannot create client with service name: %v", e)
+		return nil, NewNoEndpointFoundError(fmt.Errorf("cannot create client with service name: %s", service), e)
 	}
 
 	cp := c.shallowCopy()
@@ -97,7 +97,7 @@ func (c *client) WithService(service string, opts ...SDOptions) (Client, error) 
 func (c *client) WithBaseUrl(baseUrl string) (Client, error) {
 	endpointer, e := NewStaticTargetResolver(baseUrl)
 	if e != nil {
-		return nil, NewNoEndpointFoundError("cannot create client with base URL: %v", e)
+		return nil, NewNoEndpointFoundError(fmt.Errorf("cannot create client with base URL: %s", baseUrl), e)
 	}
 
 	cp := c.shallowCopy()

--- a/pkg/integrate/httpclient/error.go
+++ b/pkg/integrate/httpclient/error.go
@@ -176,9 +176,12 @@ func (e Error) WithMessage(msg string, args ...interface{}) *Error {
 	return newError(NewCodedError(e.CodedError.Code(), fmt.Errorf(msg, args...)), e.Response)
 }
 
-/**********************
-	Constructors
- **********************/
+/*
+*********************
+
+		Constructors
+	 *********************
+*/
 func newError(codedErr *CodedError, errResp *ErrorResponse) *Error {
 	err := &Error{
 		CodedError: *codedErr,
@@ -218,7 +221,7 @@ func NewErrorWithStatusCode(e interface{}, resp *http.Response, rawBody []byte, 
 	case resp.StatusCode >= 500 && resp.StatusCode <= 599:
 		code = ErrorCodeGenericServerSide
 	default:
-		return NewError(ErrorCodeInternal, "attempt to create response error with non error status code %d", resp.StatusCode)
+		return NewError(ErrorCodeInternal, fmt.Errorf("attempt to create response error with non error status code %d", resp.StatusCode))
 	}
 	return NewErrorWithResponse(code, e, resp, rawBody, causes...)
 }

--- a/test/sdtest/client.go
+++ b/test/sdtest/client.go
@@ -18,18 +18,19 @@ package sdtest
 
 import (
 	"context"
+	"fmt"
 	"github.com/cisco-open/go-lanai/pkg/discovery"
 	"time"
 )
 
 type ClientMock struct {
-	ctx context.Context
+	ctx        context.Context
 	Instancers map[string]*InstancerMock
 }
 
 func NewMockClient(ctx context.Context) *ClientMock {
 	return &ClientMock{
-		ctx: ctx,
+		ctx:        ctx,
 		Instancers: map[string]*InstancerMock{},
 	}
 }
@@ -41,6 +42,10 @@ func (c *ClientMock) Context() context.Context {
 }
 
 func (c *ClientMock) Instancer(serviceName string) (discovery.Instancer, error) {
+	if serviceName == "" {
+		return nil, fmt.Errorf("empty service name")
+	}
+
 	if instancer, ok := c.Instancers[serviceName]; ok {
 		return instancer, nil
 	}


### PR DESCRIPTION
## Description

This PR addresses this issue https://github.com/cisco-open/go-lanai/issues/408 by formatting the error messages.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
