### PR TITLE
Add support for custom token granter, enhancer, auth registry and tenant hierachy loader

### DIFF
--- a/cmd/lanai-cli/initcmd/Dockerfile.tmpl
+++ b/cmd/lanai-cli/initcmd/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=debian:bookworm
-ARG BUILDER_IMAGE=golang:1.21-bookworm
+ARG BUILDER_IMAGE=golang:1.24-bookworm
 
 ## Build Container ##
 FROM ${BUILDER_IMAGE} AS builder

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -16,12 +16,12 @@ In this example, the source code contains the fully finished service. This step 
 involved in writing this service.
 
 ### 1. Create the Initial Project
-This involves the following steps. For detail explanation of each step, see the [developer guide](../docs/Develop.md)
+This involves the following steps. For detail explanation of each step, see the [developer guide](../../docs/Develop.md)
 
 1. Create Module.yml
 2. Add go.mod 
 3. Add Makefile 
-4. call ```shell make init CLI_TAG="develop"``` to initialize the project 
+4. call ```shell make init CLI_TAG="main"``` to initialize the project 
 
 ### 2. Adding Main File
 Add the main file corresponding to the definition in Module.yml. The main file is the entry point for this service.

--- a/examples/auth/pkg/service/clients.go
+++ b/examples/auth/pkg/service/clients.go
@@ -1,1 +1,0 @@
-package service

--- a/pkg/integrate/httpclient/client.go
+++ b/pkg/integrate/httpclient/client.go
@@ -21,12 +21,15 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cisco-open/go-lanai/pkg/discovery"
+	"github.com/cisco-open/go-lanai/pkg/utils"
 	"github.com/cisco-open/go-lanai/pkg/utils/order"
+	"net/url"
 	"time"
 )
 
 var (
 	insecureInstanceMatcher = discovery.InstanceWithTagKV("secure", "false", true)
+	supportedSchemes        = utils.NewStringSet("http", "https")
 )
 
 type clientDefaults struct {
@@ -98,17 +101,6 @@ func (c *client) WithBaseUrl(baseUrl string) (Client, error) {
 	endpointer, e := NewStaticTargetResolver(baseUrl)
 	if e != nil {
 		return nil, NewNoEndpointFoundError(fmt.Errorf("cannot create client with base URL: %s", baseUrl), e)
-	}
-
-	cp := c.shallowCopy()
-	cp.resolver = endpointer
-	return cp.WithConfig(defaultExtHostConfig()), nil
-}
-
-func (c *client) WithNoTargetResolver() (Client, error) {
-	endpointer, e := NewNoOpTargetResolver()
-	if e != nil {
-		return nil, NewNoEndpointFoundError(fmt.Errorf("cannot create client"), e)
 	}
 
 	cp := c.shallowCopy()
@@ -214,9 +206,13 @@ func (c *client) shallowCopy() *client {
 
 func (c *client) executor(request *Request, resolver TargetResolver, dec DecodeResponseFunc) Retryable {
 	return func(ctx context.Context) (interface{}, error) {
-		target, e := resolver.Resolve(ctx, request)
-		if e != nil {
-			return nil, e
+		target, e := url.Parse(request.Path)
+		// only need to resolve the target if the request.Path is not absolute
+		if e != nil || !supportedSchemes.Has(target.Scheme) {
+			target, e = resolver.Resolve(ctx, request)
+			if e != nil {
+				return nil, e
+			}
 		}
 
 		req, e := request.CreateFunc(ctx, request.Method, target)

--- a/pkg/integrate/httpclient/client.go
+++ b/pkg/integrate/httpclient/client.go
@@ -105,6 +105,17 @@ func (c *client) WithBaseUrl(baseUrl string) (Client, error) {
 	return cp.WithConfig(defaultExtHostConfig()), nil
 }
 
+func (c *client) WithNoTargetResolver() (Client, error) {
+	endpointer, e := NewNoOpTargetResolver()
+	if e != nil {
+		return nil, NewNoEndpointFoundError(fmt.Errorf("cannot create client"), e)
+	}
+
+	cp := c.shallowCopy()
+	cp.resolver = endpointer
+	return cp.WithConfig(defaultExtHostConfig()), nil
+}
+
 func (c *client) WithConfig(config *ClientConfig) Client {
 	mergeConfig(config, c.config)
 	cp := c.shallowCopy()

--- a/pkg/integrate/httpclient/client_test.go
+++ b/pkg/integrate/httpclient/client_test.go
@@ -394,8 +394,7 @@ func SubTestWithURLEncoded(di *TestDI) test.GomegaSubTestFunc {
 
 func SubTestWithAbsoluteUrl(di *TestDI) test.GomegaSubTestFunc {
 	return func(ctx context.Context, t *testing.T, g *gomega.WithT) {
-		client, e := di.HttpClient.WithNoTargetResolver()
-		g.Expect(e).To(Succeed(), "client without target resolver should be available")
+		client := di.HttpClient
 
 		random := utils.RandomString(20)
 		now := time.Now().Format(time.RFC3339)

--- a/pkg/integrate/httpclient/context.go
+++ b/pkg/integrate/httpclient/context.go
@@ -44,10 +44,7 @@ type Client interface {
 	// The returned client is responsible to perform retrying.
 	// The returned client is goroutine-safe and can be reused
 	WithBaseUrl(baseUrl string) (Client, error)
-
-	// WithNoTargetResolver expects the request to contain the absolute url
-	WithNoTargetResolver() (Client, error)
-
+	
 	// WithConfig create a shallow copy of the client with specified config.
 	// Service (with LB) or BaseURL cannot be changed with this method.
 	// If any field of provided config is zero value, this value is not applied.

--- a/pkg/integrate/httpclient/context.go
+++ b/pkg/integrate/httpclient/context.go
@@ -45,6 +45,9 @@ type Client interface {
 	// The returned client is goroutine-safe and can be reused
 	WithBaseUrl(baseUrl string) (Client, error)
 
+	// WithNoTargetResolver expects the request to contain the absolute url
+	WithNoTargetResolver() (Client, error)
+
 	// WithConfig create a shallow copy of the client with specified config.
 	// Service (with LB) or BaseURL cannot be changed with this method.
 	// If any field of provided config is zero value, this value is not applied.

--- a/pkg/integrate/httpclient/resolver_static.go
+++ b/pkg/integrate/httpclient/resolver_static.go
@@ -24,10 +24,3 @@ func NewStaticTargetResolver(baseUrl string) (TargetResolverFunc, error) {
 		return &uri, nil
 	}, nil
 }
-
-func NewNoOpTargetResolver() (TargetResolverFunc, error) {
-	return func(ctx context.Context, req *Request) (*url.URL, error) {
-		uri, e := url.Parse(req.Path)
-		return uri, e
-	}, nil
-}

--- a/pkg/integrate/httpclient/resolver_static.go
+++ b/pkg/integrate/httpclient/resolver_static.go
@@ -25,4 +25,9 @@ func NewStaticTargetResolver(baseUrl string) (TargetResolverFunc, error) {
 	}, nil
 }
 
-
+func NewNoOpTargetResolver() (TargetResolverFunc, error) {
+	return func(ctx context.Context, req *Request) (*url.URL, error) {
+		uri, e := url.Parse(req.Path)
+		return uri, e
+	}, nil
+}

--- a/pkg/security/config/authserver/config.go
+++ b/pkg/security/config/authserver/config.go
@@ -181,6 +181,9 @@ type Configuration struct {
 	OpenIDSSOEnabled      bool
 	SamlIdpSigningMethod  string
 	ApprovalStore         auth.ApprovalStore
+	CustomTokenGranter    []auth.TokenGranter
+	CustomTokenEnhancer   []auth.TokenEnhancer
+	CustomAuthRegistry    auth.AuthorizationRegistry
 
 	// not directly configurable items
 	appContext                *bootstrap.ApplicationContext
@@ -265,6 +268,18 @@ func (c *Configuration) tokenGranter() auth.TokenGranter {
 			granters = append(granters, passwordGranter)
 		}
 
+		for _, custom := range c.CustomTokenGranter {
+			switch v := custom.(type) {
+			case auth.CustomizableTokenGranter:
+				v.Customize(func(o *auth.TokenGranterOption) {
+					o.AuthService = c.authorizationService()
+				})
+			default:
+				// do nothing
+			}
+		}
+		granters = append(granters, c.CustomTokenGranter...)
+
 		c.sharedTokenGranter = auth.NewCompositeTokenGranter(granters...)
 	}
 	return c.sharedTokenGranter
@@ -295,7 +310,11 @@ func (c *Configuration) contextDetailsStore() security.ContextDetailsStore {
 
 func (c *Configuration) authorizationRegistry() auth.AuthorizationRegistry {
 	if c.sharedAuthRegistry == nil {
-		c.sharedAuthRegistry = c.contextDetailsStore().(auth.AuthorizationRegistry)
+		if c.CustomAuthRegistry != nil {
+			c.sharedAuthRegistry = c.CustomAuthRegistry
+		} else {
+			c.sharedAuthRegistry = c.contextDetailsStore().(auth.AuthorizationRegistry)
+		}
 	}
 	return c.sharedAuthRegistry
 }
@@ -329,6 +348,7 @@ func (c *Configuration) authorizationService() auth.AuthorizationService {
 				})
 				conf.PostTokenEnhancers = append(conf.PostTokenEnhancers, openidEnhancer)
 			}
+			conf.TokenEnhancers = append(conf.TokenEnhancers, c.CustomTokenEnhancer...)
 		})
 	}
 

--- a/pkg/security/config/authserver/config.go
+++ b/pkg/security/config/authserver/config.go
@@ -270,10 +270,8 @@ func (c *Configuration) tokenGranter() auth.TokenGranter {
 
 		for _, custom := range c.CustomTokenGranter {
 			switch v := custom.(type) {
-			case auth.CustomizableTokenGranter:
-				v.Customize(func(o *auth.TokenGranterOption) {
-					o.AuthService = c.authorizationService()
-				})
+			case auth.AuthorizationServiceInjector:
+				v.Inject(c.authorizationService())
 			default:
 				// do nothing
 			}

--- a/pkg/security/config/testdata/application-test.yml
+++ b/pkg/security/config/testdata/application-test.yml
@@ -93,6 +93,11 @@ mocking:
       redirect-uris: ["localhost:*/**"]
       tenants: ["id-tenant-3"]
       scopes: "scope_a,scope_b"
+    custom-grant-client:
+      id: "custom-grant-client"
+      secret: "test-secret"
+      access-token-validity: 3600s
+      grant-types: "custom_grant"
   accounts:
     system:
       username: "system"

--- a/pkg/security/config/testdata/authserver_configurer.go
+++ b/pkg/security/config/testdata/authserver_configurer.go
@@ -49,6 +49,9 @@ type authDI struct {
 	Properties          authserver.AuthServerProperties
 	PasswdIDPProperties passwdidp.PwdAuthProperties
 	SamlIDPProperties   extsamlidp.SamlAuthProperties
+	CustomTokenGranter  auth.TokenGranter          `optional:"true"`
+	CustomTokenEnhancer auth.TokenEnhancer         `optional:"true"`
+	CustomAuthRegistry  auth.AuthorizationRegistry `optional:"true"`
 }
 
 func NewAuthServerConfigurer(di authDI) authserver.AuthorizationServerConfigurer {
@@ -71,7 +74,15 @@ func NewAuthServerConfigurer(di authDI) authserver.AuthorizationServerConfigurer
 		config.ProviderStore = sectest.MockedProviderStore{}
 		config.UserPasswordEncoder = di.PasswordEncoder
 		config.SessionSettingService = StaticSessionSettingService(1)
-		config.CustomTokenEnhancer = []auth.TokenEnhancer{auth.NewLegacyTokenEnhancer()}
+		if di.CustomTokenEnhancer != nil {
+			config.CustomTokenEnhancer = []auth.TokenEnhancer{di.CustomTokenEnhancer}
+		}
+		if di.CustomTokenGranter != nil {
+			config.CustomTokenGranter = []auth.TokenGranter{di.CustomTokenGranter}
+		}
+		if di.CustomAuthRegistry != nil {
+			config.CustomAuthRegistry = di.CustomAuthRegistry
+		}
 	}
 }
 

--- a/pkg/security/config/testdata/authserver_configurer.go
+++ b/pkg/security/config/testdata/authserver_configurer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cisco-open/go-lanai/pkg/security/idp/extsamlidp"
 	"github.com/cisco-open/go-lanai/pkg/security/idp/passwdidp"
 	"github.com/cisco-open/go-lanai/pkg/security/idp/unknownIdp"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2/auth"
 	"github.com/cisco-open/go-lanai/pkg/security/passwd"
 	"github.com/cisco-open/go-lanai/test/samltest"
 	"github.com/cisco-open/go-lanai/test/sectest"
@@ -35,8 +36,8 @@ const (
 	IdpDomainExtSAML   = "saml.lanai.com"
 	ExtSamlIdpName     = "ext-saml-idp"
 	ExtSamlIdpEntityID = "http://external.saml.com/samlidp/metadata"
-	ExtSamlIdpSSOUrl = "http://external.saml.com/samlidp/authorize"
-	ExtSamlIdpSLOUrl = "http://external.saml.com/samlidp/logout"
+	ExtSamlIdpSSOUrl   = "http://external.saml.com/samlidp/authorize"
+	ExtSamlIdpSLOUrl   = "http://external.saml.com/samlidp/logout"
 )
 
 type authDI struct {
@@ -70,6 +71,7 @@ func NewAuthServerConfigurer(di authDI) authserver.AuthorizationServerConfigurer
 		config.ProviderStore = sectest.MockedProviderStore{}
 		config.UserPasswordEncoder = di.PasswordEncoder
 		config.SessionSettingService = StaticSessionSettingService(1)
+		config.CustomTokenEnhancer = []auth.TokenEnhancer{auth.NewLegacyTokenEnhancer()}
 	}
 }
 
@@ -81,7 +83,7 @@ func (s StaticSessionSettingService) GetMaximumSessions(ctx context.Context) int
 
 func NewMockedIDPManager() *samltest.MockedIdpManager {
 	return samltest.NewMockedIdpManager(func(opt *samltest.IdpManagerMockOption) {
-		opt.IDPList = []idp.IdentityProvider {
+		opt.IDPList = []idp.IdentityProvider{
 			extsamlidp.NewIdentityProvider(func(opt *extsamlidp.SamlIdpDetails) {
 				opt.EntityId = ExtSamlIdpEntityID
 				opt.Domain = IdpDomainExtSAML

--- a/pkg/security/config/testdata/custom_auth_registry.go
+++ b/pkg/security/config/testdata/custom_auth_registry.go
@@ -1,0 +1,56 @@
+package testdata
+
+import (
+	"context"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2/auth"
+)
+
+type CustomAuthRegistry struct {
+	RegistrationCount int
+}
+
+func NewCustomAuthRegistry() auth.AuthorizationRegistry {
+	return &CustomAuthRegistry{}
+}
+
+func (c *CustomAuthRegistry) RegisterRefreshToken(ctx context.Context, token oauth2.RefreshToken, oauth oauth2.Authentication) error {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) RegisterAccessToken(ctx context.Context, token oauth2.AccessToken, oauth oauth2.Authentication) error {
+	c.RegistrationCount++
+	return nil
+}
+
+func (c *CustomAuthRegistry) ReadStoredAuthorization(ctx context.Context, token oauth2.RefreshToken) (oauth2.Authentication, error) {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) FindSessionId(ctx context.Context, token oauth2.Token) (string, error) {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) RevokeRefreshToken(ctx context.Context, token oauth2.RefreshToken) error {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) RevokeAccessToken(ctx context.Context, token oauth2.AccessToken) error {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) RevokeAllAccessTokens(ctx context.Context, token oauth2.RefreshToken) error {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) RevokeUserAccess(ctx context.Context, username string, revokeRefreshToken bool) error {
+	panic("implement me")
+}
+
+func (c *CustomAuthRegistry) RevokeClientAccess(ctx context.Context, clientId string, revokeRefreshToken bool) error {
+	panic("implement me")
+}
+
+func (c CustomAuthRegistry) RevokeSessionAccess(ctx context.Context, sessionId string, revokeRefreshToken bool) error {
+	panic("implement me")
+}

--- a/pkg/security/config/testdata/custom_token_enhancer.go
+++ b/pkg/security/config/testdata/custom_token_enhancer.go
@@ -1,0 +1,62 @@
+package testdata
+
+import (
+	"context"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2/auth"
+)
+
+type CustomClaims struct {
+	oauth2.FieldClaimsMapper
+	oauth2.Claims
+	MyClaim string `claim:"MyClaim"`
+}
+
+func (c *CustomClaims) MarshalJSON() ([]byte, error) {
+	return c.FieldClaimsMapper.DoMarshalJSON(c)
+}
+
+func (c *CustomClaims) UnmarshalJSON(bytes []byte) error {
+	return c.FieldClaimsMapper.DoUnmarshalJSON(c, bytes)
+}
+
+func (c *CustomClaims) Get(claim string) interface{} {
+	return c.FieldClaimsMapper.Get(c, claim)
+}
+
+func (c *CustomClaims) Has(claim string) bool {
+	return c.FieldClaimsMapper.Has(c, claim)
+}
+
+func (c *CustomClaims) Set(claim string, value interface{}) {
+	c.FieldClaimsMapper.Set(c, claim, value)
+}
+
+func (c *CustomClaims) Values() map[string]interface{} {
+	return c.FieldClaimsMapper.Values(c)
+}
+
+type CustomTokenEnhancer struct{}
+
+func NewCustomTokenEnhancer() auth.TokenEnhancer {
+	return &CustomTokenEnhancer{}
+}
+
+func (c *CustomTokenEnhancer) Enhance(ctx context.Context, token oauth2.AccessToken, oauth oauth2.Authentication) (oauth2.AccessToken, error) {
+	t, ok := token.(*oauth2.DefaultAccessToken)
+	if !ok {
+		return nil, oauth2.NewInternalError("unsupported token implementation %T", t)
+	}
+
+	if t.Claims() == nil {
+		return nil, oauth2.NewInternalError("need to be placed after BasicClaimsEnhancer")
+	}
+
+	customClaims := &CustomClaims{
+		Claims: t.Claims(),
+	}
+	customClaims.MyClaim = "my_claim_value"
+
+	t.SetClaims(customClaims)
+	return t, nil
+}

--- a/pkg/security/config/testdata/custom_token_granter.go
+++ b/pkg/security/config/testdata/custom_token_granter.go
@@ -36,6 +36,10 @@ type CustomTokenGranter struct {
 	authService auth.AuthorizationService
 }
 
+func (c *CustomTokenGranter) Inject(authService auth.AuthorizationService) {
+	c.authService = authService
+}
+
 func NewCustomTokenGranter() auth.TokenGranter {
 	return &CustomTokenGranter{}
 }
@@ -60,12 +64,4 @@ func (c *CustomTokenGranter) Grant(ctx context.Context, request *auth.TokenReque
 		opt.Details = &CustomContextDetails{}
 	})
 	return c.authService.CreateAccessToken(ctx, oauth)
-}
-
-func (c *CustomTokenGranter) Customize(options ...func(o *auth.TokenGranterOption)) {
-	config := &auth.TokenGranterOption{}
-	for _, opt := range options {
-		opt(config)
-	}
-	c.authService = config.AuthService
 }

--- a/pkg/security/config/testdata/custom_token_granter.go
+++ b/pkg/security/config/testdata/custom_token_granter.go
@@ -1,0 +1,71 @@
+package testdata
+
+import (
+	"context"
+	"github.com/cisco-open/go-lanai/pkg/security"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2/auth"
+	"github.com/cisco-open/go-lanai/pkg/utils"
+	"time"
+)
+
+type CustomContextDetails struct {
+}
+
+func (c CustomContextDetails) ExpiryTime() time.Time {
+	return time.Now().Add(time.Minute)
+}
+
+func (c CustomContextDetails) IssueTime() time.Time {
+	return time.Now()
+}
+
+func (c CustomContextDetails) Roles() utils.StringSet {
+	return utils.NewStringSet()
+}
+
+func (c CustomContextDetails) Permissions() utils.StringSet {
+	return utils.NewStringSet()
+}
+
+func (c CustomContextDetails) AuthenticationTime() time.Time {
+	return time.Now()
+}
+
+type CustomTokenGranter struct {
+	authService auth.AuthorizationService
+}
+
+func NewCustomTokenGranter() auth.TokenGranter {
+	return &CustomTokenGranter{}
+}
+
+func (c *CustomTokenGranter) Grant(ctx context.Context, request *auth.TokenRequest) (oauth2.AccessToken, error) {
+	if "custom_grant" != request.GrantType {
+		return nil, nil
+	}
+
+	client, e := auth.RetrieveFullyAuthenticatedClient(ctx)
+	if e != nil {
+		return nil, oauth2.NewInvalidGrantError("requires client secret validated")
+	}
+
+	req := request.OAuth2Request(client)
+	oauth := oauth2.NewAuthentication(func(opt *oauth2.AuthOption) {
+		opt.Request = req
+		opt.UserAuth = oauth2.NewUserAuthentication(func(opt *oauth2.UserAuthOption) {
+			opt.Principal = "custom_grant_principal"
+			opt.State = security.StateAuthenticated
+		})
+		opt.Details = &CustomContextDetails{}
+	})
+	return c.authService.CreateAccessToken(ctx, oauth)
+}
+
+func (c *CustomTokenGranter) Customize(options ...func(o *auth.TokenGranterOption)) {
+	config := &auth.TokenGranterOption{}
+	for _, opt := range options {
+		opt(config)
+	}
+	c.authService = config.AuthService
+}

--- a/pkg/security/oauth2/auth/granter.go
+++ b/pkg/security/oauth2/auth/granter.go
@@ -31,6 +31,10 @@ type TokenGranter interface {
 	Grant(ctx context.Context, request *TokenRequest) (oauth2.AccessToken, error)
 }
 
+// AuthorizationServiceInjector
+// By implementing this interface, a component can ask the framework to call its Inject method
+// to get a reference to the AuthorizationService.
+// Currently only component that also implements TokenGranter interface will have its Inject method be called.
 type AuthorizationServiceInjector interface {
 	Inject(authService AuthorizationService)
 }

--- a/pkg/security/oauth2/auth/granter.go
+++ b/pkg/security/oauth2/auth/granter.go
@@ -17,9 +17,9 @@
 package auth
 
 import (
-    "context"
-    "fmt"
-    "github.com/cisco-open/go-lanai/pkg/security/oauth2"
+	"context"
+	"fmt"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2"
 )
 
 type TokenGranter interface {
@@ -31,12 +31,20 @@ type TokenGranter interface {
 	Grant(ctx context.Context, request *TokenRequest) (oauth2.AccessToken, error)
 }
 
+type TokenGranterOption struct {
+	AuthService AuthorizationService
+}
+
+type CustomizableTokenGranter interface {
+	Customize(options ...func(o *TokenGranterOption))
+}
+
 // CompositeTokenGranter implements TokenGranter
 type CompositeTokenGranter struct {
 	delegates []TokenGranter
 }
 
-func NewCompositeTokenGranter(delegates...TokenGranter) *CompositeTokenGranter {
+func NewCompositeTokenGranter(delegates ...TokenGranter) *CompositeTokenGranter {
 	return &CompositeTokenGranter{
 		delegates: delegates,
 	}

--- a/pkg/security/oauth2/auth/granter.go
+++ b/pkg/security/oauth2/auth/granter.go
@@ -31,12 +31,8 @@ type TokenGranter interface {
 	Grant(ctx context.Context, request *TokenRequest) (oauth2.AccessToken, error)
 }
 
-type TokenGranterOption struct {
-	AuthService AuthorizationService
-}
-
-type CustomizableTokenGranter interface {
-	Customize(options ...func(o *TokenGranterOption))
+type AuthorizationServiceInjector interface {
+	Inject(authService AuthorizationService)
 }
 
 // CompositeTokenGranter implements TokenGranter

--- a/pkg/security/oauth2/auth/service.go
+++ b/pkg/security/oauth2/auth/service.go
@@ -17,15 +17,15 @@
 package auth
 
 import (
-    "context"
-    "fmt"
-    "github.com/cisco-open/go-lanai/pkg/security"
-    "github.com/cisco-open/go-lanai/pkg/security/oauth2"
-    "github.com/cisco-open/go-lanai/pkg/security/oauth2/common"
-    "github.com/cisco-open/go-lanai/pkg/tenancy"
-    "github.com/cisco-open/go-lanai/pkg/utils"
-    "github.com/google/uuid"
-    "time"
+	"context"
+	"fmt"
+	"github.com/cisco-open/go-lanai/pkg/security"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2"
+	"github.com/cisco-open/go-lanai/pkg/security/oauth2/common"
+	"github.com/cisco-open/go-lanai/pkg/tenancy"
+	"github.com/cisco-open/go-lanai/pkg/utils"
+	"github.com/google/uuid"
+	"time"
 )
 
 var (
@@ -76,7 +76,6 @@ func NewDefaultAuthorizationService(opts ...DASOptions) *DefaultAuthorizationSer
 		TokenEnhancers: []TokenEnhancer{
 			&ExpiryTokenEnhancer{},
 			&basicEnhancer,
-			&LegacyTokenEnhancer{},
 			&ResourceIdTokenEnhancer{},
 			&DetailsTokenEnhancer{},
 			&refreshTokenEnhancer,

--- a/pkg/security/oauth2/auth/token_enhance_legacy.go
+++ b/pkg/security/oauth2/auth/token_enhance_legacy.go
@@ -68,7 +68,7 @@ func (c *legacyClaims) Values() map[string]interface{} {
 // but deprecated in Go version
 type LegacyTokenEnhancer struct{}
 
-func NewLegacyTokenEnhancer() *LegacyTokenEnhancer {
+func NewLegacyTokenEnhancer() TokenEnhancer {
 	return &LegacyTokenEnhancer{}
 }
 

--- a/pkg/security/oauth2/auth/token_enhance_legacy.go
+++ b/pkg/security/oauth2/auth/token_enhance_legacy.go
@@ -66,7 +66,11 @@ func (c *legacyClaims) Values() map[string]interface{} {
 // LegacyTokenEnhancer implements order.Ordered and TokenEnhancer
 // LegacyTokenEnhancer add legacy claims and response fields that was supported by Java version of IDM
 // but deprecated in Go version
-type LegacyTokenEnhancer struct {}
+type LegacyTokenEnhancer struct{}
+
+func NewLegacyTokenEnhancer() *LegacyTokenEnhancer {
+	return &LegacyTokenEnhancer{}
+}
 
 func (te *LegacyTokenEnhancer) Order() int {
 	return TokenEnhancerOrderDetailsClaims

--- a/pkg/tenancy/loader/loader_test.go
+++ b/pkg/tenancy/loader/loader_test.go
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 type testDI struct {
 	fx.In
 	DB              *gorm.DB `optional:"true"`
-	InternalLoader  Loader   `name:"tenant_hierarchy/loader"`
+	InternalLoader  Loader   `name:"tenant-hierarchy/loader"`
 	ClientFactory   redis.ClientFactory
 	AppCtx          *bootstrap.ApplicationContext
 	TestTenantStore *TestTenantStore

--- a/pkg/tenancy/loader/package.go
+++ b/pkg/tenancy/loader/package.go
@@ -38,7 +38,7 @@ var Module = &bootstrap.Module{
 }
 
 const (
-	fxNameLoader = "tenant_hierarchy/loader"
+	fxNameLoader = "tenant-hierarchy/loader"
 )
 
 func Use() {
@@ -81,7 +81,7 @@ func provideLoader(di loaderDI) Loader {
 type initDi struct {
 	fx.In
 	AppCtx          *bootstrap.ApplicationContext
-	EffectiveLoader Loader `name:"tenant_hierarchy/loader"`
+	EffectiveLoader Loader `name:"tenant-hierarchy/loader"`
 }
 
 func initializeTenantHierarchy(di initDi) error {

--- a/pkg/tenancy/loader/package.go
+++ b/pkg/tenancy/loader/package.go
@@ -29,13 +29,17 @@ var logger = log.New("Tenancy.Load")
 var internalLoader Loader
 
 var Module = &bootstrap.Module{
-	Name: "tenancy-loader",
+	Name:       "tenancy-loader",
 	Precedence: bootstrap.TenantHierarchyLoaderPrecedence,
 	Options: []fx.Option{
-		fx.Provide(provideLoader),
+		fx.Provide(defaultLoader()),
 		fx.Invoke(initializeTenantHierarchy),
 	},
 }
+
+const (
+	fxNameLoader = "tenant_hierarchy/loader"
+)
 
 func Use() {
 	tenancy.Use()
@@ -44,14 +48,26 @@ func Use() {
 
 type loaderDI struct {
 	fx.In
-	Ctx *bootstrap.ApplicationContext
-	Store TenantHierarchyStore
-	Cf redis.ClientFactory
-	Prop tenancy.CacheProperties
-	Accessor tenancy.Accessor `name:"tenancy/accessor"`
+	Ctx           *bootstrap.ApplicationContext
+	Store         TenantHierarchyStore
+	Cf            redis.ClientFactory
+	Prop          tenancy.CacheProperties
+	Accessor      tenancy.Accessor `name:"tenancy/accessor"`
+	UnnamedLoader Loader           `optional:"true"`
+}
+
+func defaultLoader() fx.Annotated {
+	return fx.Annotated{
+		Name:   fxNameLoader,
+		Target: provideLoader,
+	}
 }
 
 func provideLoader(di loaderDI) Loader {
+	if di.UnnamedLoader != nil {
+		internalLoader = di.UnnamedLoader
+		return di.UnnamedLoader
+	}
 	rc, e := di.Cf.New(di.Ctx, func(opt *redis.ClientOption) {
 		opt.DbIndex = di.Prop.DbIndex
 	})
@@ -62,9 +78,16 @@ func provideLoader(di loaderDI) Loader {
 	return internalLoader
 }
 
-func initializeTenantHierarchy (ctx *bootstrap.ApplicationContext, loader Loader) error {
+type initDi struct {
+	fx.In
+	AppCtx          *bootstrap.ApplicationContext
+	EffectiveLoader Loader `name:"tenant_hierarchy/loader"`
+}
+
+func initializeTenantHierarchy(di initDi) error {
+	ctx := di.AppCtx
 	logger.WithContext(ctx).Infof("started loading tenant hierarchy")
-	internalLoader = loader
+	internalLoader = di.EffectiveLoader
 	err := LoadTenantHierarchy(ctx)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("tenant hierarchy not loaded due to %v", err)
@@ -72,4 +95,5 @@ func initializeTenantHierarchy (ctx *bootstrap.ApplicationContext, loader Loader
 		logger.WithContext(ctx).Infof("finished loading tenant hierarchy")
 	}
 	return err
+
 }


### PR DESCRIPTION
## Description
In order for services to implement their own token granter on top of the oauth2 spec. We need to be able to let service developers provide their own implementation of token granter and token enhancer.

In addition, it's useful for service to be able to provide their own implementation of auth registry (for example, in the case they don't want to store their JWT token), or tenant hierarchy loader (if they don't want the default redis based implementation).

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
