### PR TITLE
Update golangci-lint version to 2.12.2

### DIFF
--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: "Code Quality Analysis"
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.2.2
+        version: v2.12.2
         args: -c=build/ci/golangci.yml --timeout=10m --issues-exit-code=${{ inputs.fail_on_lint_issues == 'true' && 1 || 0 }}
         # if fail_on_lint_issues == true, we assume it's a PR verification
         only-new-issues: ${{ inputs.fail_on_lint_issues == 'true' && 'true' || 'false' }}


### PR DESCRIPTION
## Description
 
Upgrade `golangci-lint` from `v2.2.2` to `v2.12.2` in the CI verify action (.github/actions/verify/action.yml).
 
The project's go.mod targets Go 1.26.0, but `golangci-lint v2.2.2` was built with Go 1.24. golangci-lint enforces that its build Go version must be ≥ the project's target version, causing the linter to fail with:
 
> Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.0)
 
`v2.12.2` (released 2026-05-06) is built with Go 1.26 and resolves this incompatibility.
 
## Type of Change
 
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
 
## Checklist
 
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass